### PR TITLE
Remove duplicate CSS lint blocks

### DIFF
--- a/.replit
+++ b/.replit
@@ -112,31 +112,6 @@ start = "vscode-css-language-server --stdio"
       documentation = true
       references = true
     
-      [languages.css.languageServer.configuration.scss.lint]
-      # Configure linting
-      # ignore = don't show any warning or error
-      # warning = show yellow underline
-      # error = show red underline
-      argumentsInColorFunction = "error" # Invalid number of parameters
-      boxModel = "ignore" # Do not use width or height when using padding or border
-      compatibleVendorPrefixes = "ignore"  # When using a vendor-specific prefix make sure to also include all other vendor-specific properties"
-      duplicateProperties = "warning" # Do not use duplicate style definitions
-      emptyRules = "warning" # Do not use empty rulesets
-      float = "ignore" # Avoid using 'float'. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes.
-      fontFaceProperties = "warning" # @font-face rule must define 'src' and 'font-family' properties 
-      hexColorLength = "error" # Hex colors must consist of three, four, six or eight hex numbers
-      idSelector = "ignore" # Selectors should not contain IDs because these rules are too tightly coupled with the HTML.
-      ieHack = "ignore" # IE hacks are only necessary when supporting IE7 and older
-      important = "ignore" # Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored.
-      importStatement = "ignore" # Import statements do not load in parallel
-      propertyIgnoredDueToDisplay = "warning" # Property is ignored due to the display
-      universalSelector = "ignore" # The universal selector (*) is known to be slow
-      unknownAtRules = "warning" # Unknown at-rule
-      unknownProperties = "warning" # Unknown property.
-      validProperties = [ ] # add some properties that the linter doesn't know about
-      unknownVendorSpecificProperties = "ignore" # Unknown vendor specific property.
-      vendorPrefix = "warning" # When using a vendor-specific prefix also include the standard property
-      zeroUnits = "ignore" # No unit for zero needed"
     
     [languages.css.languageServer.configuration.less]
     validate = true
@@ -149,31 +124,5 @@ start = "vscode-css-language-server --stdio"
       documentation = true
       references = true
     
-      [languages.css.languageServer.configuration.less.lint]
-      # Configure linting
-      # ignore = don't show any warning or error
-      # warning = show yellow underline
-      # error = show red underline
-      argumentsInColorFunction = "error" # Invalid number of parameters
-      boxModel = "ignore" # Do not use width or height when using padding or border
-      compatibleVendorPrefixes = "ignore"  # When using a vendor-specific prefix make sure to also include all other vendor-specific properties"
-      duplicateProperties = "warning" # Do not use duplicate style definitions
-      emptyRules = "warning" # Do not use empty rulesets
-      float = "ignore" # Avoid using 'float'. Floats lead to fragile CSS that is easy to break if one aspect of the layout changes.
-      fontFaceProperties = "warning" # @font-face rule must define 'src' and 'font-family' properties 
-      hexColorLength = "error" # Hex colors must consist of three, four, six or eight hex numbers
-      idSelector = "ignore" # Selectors should not contain IDs because these rules are too tightly coupled with the HTML.
-      ieHack = "ignore" # IE hacks are only necessary when supporting IE7 and older
-      important = "ignore" # Avoid using !important. It is an indication that the specificity of the entire CSS has gotten out of control and needs to be refactored.
-      importStatement = "ignore" # Import statements do not load in parallel
-      propertyIgnoredDueToDisplay = "warning" # Property is ignored due to the display
-      universalSelector = "ignore" # The universal selector (*) is known to be slow
-      unknownAtRules = "warning" # Unknown at-rule
-      unknownProperties = "warning" # Unknown property.
-      validProperties = [ ] # add some properties that the linter doesn't know about
-      unknownVendorSpecificProperties = "ignore" # Unknown vendor specific property.
-      vendorPrefix = "warning" # When using a vendor-specific prefix also include the standard property
-      zeroUnits = "ignore" # No unit for zero needed"
-
-[gitHubImport]
-requiredFiles = [".replit", "replit.nix", ".config"]
+[gitHubImport] //([restored final section])
+requiredFiles = [".replit", "replit.nix", ".config"] //([imported file references])


### PR DESCRIPTION
## Summary
- clean up `.replit` by removing duplicated lint configuration
- keep only the first CSS lint block
- restore `[gitHubImport]` section

## Testing
- `git status --short`