### PR TITLE
Add defer to Font Awesome script

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="robots" content="index, follow">
     <title>coreCSS Sandbox</title>
     <link rel="icon" type="image/png" href="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true"/>
-    <script src="https://kit.fontawesome.com/987e326b19.js" crossorigin="anonymous"></script>
+    <script defer src="https://kit.fontawesome.com/987e326b19.js" crossorigin="anonymous"></script> <!-- added defer attribute to load script after HTML parsing -->
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.css">
     <link rel="stylesheet" type="text/css" href="variables.css">
 </head>


### PR DESCRIPTION
## Summary
- load Font Awesome after HTML parsing by adding the `defer` attribute

## Testing
- `npm test` *(fails: no such script)*