### PR TITLE
Improve icon grid performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,55 +39,56 @@
         <div class='col card col90 flex centerAlign'>
             <h2 id='offerings'>Icon Demo</h2>
             <hr>
-            <div class='grid5'> <!--Item Container-->         
+            <div class='grid5'> <!--Item Container-->
+                <!-- TODO: bundle these icons into a sprite for fewer requests -->
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/android.png?raw=true' alt='android icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/android.png?raw=true' alt='android icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/email.png?raw=true' alt='email icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/email.png?raw=true' alt='email icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/fb.png?raw=true' alt='fb icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/fb.png?raw=true' alt='fb icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/fb_messenger.png?raw=true' alt='fb messenger icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/fb_messenger.png?raw=true' alt='fb messenger icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/github.png?raw=true' alt='github icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/github.png?raw=true' alt='github icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/insta.png?raw=true' alt='insta icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/insta.png?raw=true' alt='insta icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/linkedin.png?raw=true' alt='linkedin icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/linkedin.png?raw=true' alt='linkedin icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/patreon.png?raw=true' alt='patreon icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/patreon.png?raw=true' alt='patreon icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/phone.png?raw=true' alt='phone icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/phone.png?raw=true' alt='phone icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/pinterest.png?raw=true' alt='pinterest icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/pinterest.png?raw=true' alt='pinterest icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/reddit.png?raw=true' alt='reddit icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/reddit.png?raw=true' alt='reddit icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/shopify.png?raw=true' alt='shopify icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/shopify.png?raw=true' alt='shopify icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/signal.png?raw=true' alt='signal icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/signal.png?raw=true' alt='signal icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/skype.png?raw=true' alt='skype icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/skype.png?raw=true' alt='skype icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/snap.png?raw=true' alt='snap icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/snap.png?raw=true' alt='snap icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                 <div>
-										<img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/twitter.png?raw=true' alt='twitter icon'/> <!-- //added iconLarge class, removed inline sizing, added alt -->
-								</div>
+                                                                               <img class='icon iconLarge' src='https://github.com/Bijikyu/staticAssetsSmall/blob/main/icons/monocolor/twitter.png?raw=true' alt='twitter icon' loading="lazy"/> <!-- //added iconLarge class, removed inline sizing, added alt, lazy loading added -->
+                </div>
                
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add lazy loading for all icons in the demo grid to reduce page load time
- add comment reminding to bundle these icons into a sprite later

## Testing
- `grep -c "loading=\"lazy\"" index.html`