### PR TITLE
Add PostCSS build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Minified version:
 ```
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css">
 ```
-`core.min.css` in this repo is generated from `core.css` using `npx clean-css-cli`.
+`core.min.css` in this repo is generated from `core.css` by running `npm run build`, which processes the file with PostCSS and Autoprefixer.
 
 Copy variables.css into your local css stylesheet and change values as you like.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "corecss",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "postcss core.css -o core.min.css"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "cssnano": "^5.1.15",
+    "postcss": "^8.4.30",
+    "postcss-cli": "^10.1.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer'), //auto add vendor prefixes
+    require('cssnano')({ preset: 'default' }) //minify css
+  ]
+};


### PR DESCRIPTION
## Summary
- document how to build core.min.css via `npm run build`
- add `package.json` with PostCSS, Autoprefixer and CSSNano
- configure PostCSS to prefix and minify

## Testing
- `npm run build` *(fails: postcss not found)*