### PR TITLE
Add CDN preconnect for faster stylesheet delivery

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/png" href="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true"/>
     <link rel="preload" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css" as="style"><!-- //preloads stylesheet for faster fetch -->
     <link rel="preload" href="icons.svg" as="image" type="image/svg+xml"><!-- //preloads icon sprite -->
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- //establishes early CDN connection for faster CSS delivery -->
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css"> <!-- changed link to minified stylesheet for reduced download size -->
     <link rel="stylesheet" type="text/css" href="variables.css">
 </head>


### PR DESCRIPTION
## Summary
- add a `preconnect` hint for jsDelivr in index.html

## Testing
- `npm run build` *(fails: `postcss` not found)*