### PR TITLE
Simplify font stacks

### DIFF
--- a/core.css
+++ b/core.css
@@ -10,7 +10,7 @@ html::-webkit-scrollbar-thumb { background-color: var(--gs-mid); border: var(--b
 html { line-height: 1.15; width: 100vw;	-webkit-text-size-adjust: 100%; /* Normalizing */}
 
 /* Sectioning */
-body {height: 100vh; width: 100vw; overflow-x: hidden;	scroll-snap-type: y mandatory; font-size: 16px; font-weight: 400; font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; /* backdrop-filter: blur(10px) brightness(50%); /* Decoration */}
+body {height: 100vh; width: 100vw; overflow-x: hidden;	scroll-snap-type: y mandatory; font-size: 16px; font-weight: 400; font-family: system-ui, sans-serif; /* fallback stack simplified */ -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; /* backdrop-filter: blur(10px) brightness(50%); /* Decoration */}
 header, main, footer { width: 100%;	display: flex !important; 	justify-content: space-evenly; align-items: center; text-align: center;}
 header, footer { flex-direction: row;	background: var(--gradient-l2r);}
 header{ position: sticky; position: -webkit-sticky;	left: 0; top: 0; padding-top: 10px; z-index: 100; border-bottom: var(--borders-bright);}
@@ -26,8 +26,8 @@ details {display: block;} /* Add correct display in Edge, IE 10+, & Firefox. */
 summary {display: list-item;} /* Add correct display in all browsers. */
 
 /* Headings & Paragraphs */
-p, h1, h2, h3, h4, h5, h6 {color: var(--gs-lightest); font-family: 'Playfair Display', serif;	font-weight: 500; letter-spacing: 1px !important; line-height: 1.25; text-decoration: none; text-shadow: 1px 1px 0px #000;	text-transform: capitialize; -webkit-font-smoothing: antialiased;}
-p {display: inline-block; width: 100%; text-align: left; color: var(--gs-darkest); font-size: 20px; font-style: normal; font-weight: 400 !important;	font-family: source-serif-pro, Georgia, Cambria, "Times New Roman", Times, serif; letter-spacing: -0.003em; line-height: 32px; margin: 0 0 -0.46em 0; padding: 5px; word-wrap: break-word; margin-block-start: 1em; margin-block-end: 1em; -webkit-hyphens: none; -moz-hyphens: none; -ms-hyphens:none; hyphens: none; white-space: -moz-pre-wrap; /* Mozilla */	white-space: -hp-pre-wrap; /* HP printers */	white-space: -o-pre-wrap; /* Opera 7 */	white-space: -pre-wrap; /* Opera 4-6 */ white-space: pre-wrap; /* CSS 2.1 */	white-space: pre-line; /* CSS 3 (and 2.1 as well, actually) */ word-break: break-word; overflow-wrap: break-word; word-wrap: keep-all; /* IE */ text-rendering: optimizeLegibility;	text-shadow: none; -moz-osx-font-smoothing: antialiased; /* Firefox */}
+p, h1, h2, h3, h4, h5, h6 {color: var(--gs-lightest); font-family: system-ui, sans-serif; /* fallback stack simplified */	font-weight: 500; letter-spacing: 1px !important; line-height: 1.25; text-decoration: none; text-shadow: 1px 1px 0px #000;	text-transform: capitialize; -webkit-font-smoothing: antialiased;}
+p {display: inline-block; width: 100%; text-align: left; color: var(--gs-darkest); font-size: 20px; font-style: normal; font-weight: 400 !important;	font-family: system-ui, sans-serif; /* fallback stack simplified */ letter-spacing: -0.003em; line-height: 32px; margin: 0 0 -0.46em 0; padding: 5px; word-wrap: break-word; margin-block-start: 1em; margin-block-end: 1em; -webkit-hyphens: none; -moz-hyphens: none; -ms-hyphens:none; hyphens: none; white-space: -moz-pre-wrap; /* Mozilla */	white-space: -hp-pre-wrap; /* HP printers */	white-space: -o-pre-wrap; /* Opera 7 */	white-space: -pre-wrap; /* Opera 4-6 */ white-space: pre-wrap; /* CSS 2.1 */	white-space: pre-line; /* CSS 3 (and 2.1 as well, actually) */ word-break: break-word; overflow-wrap: break-word; word-wrap: keep-all; /* IE */ text-rendering: optimizeLegibility;	text-shadow: none; -moz-osx-font-smoothing: antialiased; /* Firefox */}
 .itemText {text-align: center; margin: 0px 10px 0px 10px;	overflow-wrap: break-word; color: var(--gs-lightest);}
 .splashText {width: 60%; 	font-size: 25px !important; font-weight: bold; text-align: center;}
 .explainer {margin: 1vh 0 5vh 0; padding: 1vh 0 0vh 0; width: 84%;	font-size: 22px !important; line-height: 1.5;}
@@ -39,7 +39,7 @@ h4 {border-bottom: 1px solid var(--color-bright);	font-weight: 300;	color: var(-
 /* Lists */
 ul { display: flex; flex-direction: row; flex-wrap: wrap;	justify-content: space-evenly; align-items: center; width: 100%; list-style-type: none; /* Decoration */}
 .offerlist {list-style: disc outside none;}
-li, ol {color: var(--gs-lightest); font-family: 'Playfair Display', serif; font-weight: bold; letter-spacing: 2px !important; text-align: -webkit-match-parent;	margin-bottom: 5px;}
+li, ol {color: var(--gs-lightest); font-family: system-ui, sans-serif; /* fallback stack simplified */ font-weight: bold; letter-spacing: 2px !important; text-align: -webkit-match-parent;	margin-bottom: 5px;}
 
 /* Media */
 img {width: auto; border-style: none;} /* Remove border on images inside links in IE 10. */


### PR DESCRIPTION
## Summary
- use `system-ui, sans-serif` for body and headings
- rebuild stylesheet

## Testing
- `npm run build` *(fails: postcss not found)*