### PR TITLE
Add postcss-cli caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ Minified version:
 ```
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css">
 ```
-`core.min.css` in this repo is generated from `core.css` by running `npm run build`, which processes the file with PostCSS and Autoprefixer.
+`core.min.css` in this repo is generated from `core.css` by running `npm run build`, which processes the file with PostCSS and Autoprefixer. The script now caches results with `postcss-cli-cache` for faster rebuilds.
+
+The `build` script in `package.json` looks like:
+```
+"scripts": {
+  "build": "postcss core.css -o core.min.css --cache"
+}
+```
+Install `postcss-cli-cache` as a dev dependency to enable caching.
 
 Copy variables.css into your local css stylesheet and change values as you like.
 

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "corecss",
   "version": "1.0.0",
   "scripts": {
-    "build": "postcss core.css -o core.min.css"
+    "build": "postcss core.css -o core.min.css --cache"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "cssnano": "^5.1.15",
     "postcss": "^8.4.30",
-    "postcss-cli": "^10.1.0"
+    "postcss-cli": "^10.1.0",
+    "postcss-cli-cache": "^1.0.0"
   },
   "browserslist": [
     ">0.5%",


### PR DESCRIPTION
## Summary
- use `postcss-cli-cache` to cache `postcss` results
- document caching dependency and script in README

## Testing
- `npm run build` *(fails: postcss not found)*