### PR TITLE
Add server CDN caching examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,27 @@ Minified version:
 
 Copy variables.css into your local css stylesheet and change values as you like.
 
+## Server/CDN configuration
 
-For best performance host icons and images on a CDN with long caching headers to avoid extra network requests.
-Serve `core.min.css`, `icons.svg`, and all image assets with `Cache-Control: public, max-age=31536000` to let browsers cache them for a year.
-Enable gzip or Brotli compression for `core.min.css` and `icons.svg` when serving them, using Nginx or CDN settings. /* instructs enabling asset compression */
+To maximize caching and compression when hosting the assets yourself or on a CDN:
 
-For best performance host icons and images on a CDN with long caching headers to avoid extra network requests. Set `Cache-Control: public, max-age=31536000` when serving `core.min.css`, `icons.svg`, and image assets to leverage browser caching.
-Enable gzip or Brotli compression on your server for these files.
+* Set `Cache-Control: public, max-age=31536000` for `core.min.css`, `icons.svg`, and all image files so browsers store them for a year.
+* Enable gzip or Brotli compression for these same files.
+
+Example Nginx snippet:
+```nginx
+location /assets/ {
+    gzip on;
+    gzip_types text/css image/svg+xml image/png image/jpeg;
+    add_header Cache-Control "public, max-age=31536000";
+}
+```
+
+Example CDN headers:
+```text
+Cache-Control: public, max-age=31536000
+Content-Encoding: br
+```
 
 
 <a href="https://www.buymeacoffee.com/bijikyu" target="_blank" rel="noopener noreferrer">Buy me a Coffee (Please)</a>


### PR DESCRIPTION
## Summary
- add a server/CDN configuration section to document caching & compression setup

## Testing
- `npm test` *(fails: Missing script "test")*