### PR TITLE
Update image CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Minified version:
 ```
 `core.min.css` in this repo is generated from `core.css` by running `npm run build`, which processes the file with PostCSS and Autoprefixer.
 
+Images like the logo can also be loaded from jsDelivr at
+`https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png`.
+Use these CDN links instead of the raw GitHub URLs for faster delivery.
+
 Copy variables.css into your local css stylesheet and change values as you like.
 
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="index, follow">
     <title>coreCSS Sandbox</title>
-    <link rel="icon" type="image/png" href="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true"/>
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png"/>
     <link rel="preload" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css" as="style"><!-- //preloads stylesheet for faster fetch -->
     <link rel="preload" href="icons.svg" as="image" type="image/svg+xml"><!-- //preloads icon sprite -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- //establishes early CDN connection for faster CSS delivery -->
@@ -16,7 +16,7 @@
 <body>
     <header>
         <div class='desktop flex centerAlign'>
-            <a href='/index.html'><img id='headerLogo' src="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true"/></a>
+            <a href='/index.html'><img id='headerLogo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png"/></a>
         </div>
     </header>
 
@@ -27,7 +27,7 @@
 		        <hr>
 		        <div id='splash' class='flex centerAlign row center'>
 		            <div class='col center centerAlign'>
-		                <img id="logoTransImg" src="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true" alt="Logo"/>   
+		                <img id="logoTransImg" src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" alt="Logo"/>   
 		            </div>
 		            <div class='col col50 center centerAlign'>
 		                <p id="splashText">This html page provided as a sandbox to test changing the CSS variables. If you find the logo ugly, know it was made in 5 min by AI.</p>
@@ -106,7 +106,7 @@
             </div>
             <div class="col footerDesktop tricol">
                 <div class='flex centerAlign col'>
-                    <img class='footerLogo logo' src="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true" alt="Footer logo"/>
+                    <img class='footerLogo logo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" alt="Footer logo"/>
                     <p id="footText" >coreCSS © 2022.<br>
                         Made by Brian Quezada.<br>
                     </p>
@@ -120,7 +120,7 @@
             </div>
             <div class="flex col footerMobile">
                 <div class='flex centerAlign col'>
-                    <img class='footerLogo logo' src="https://github.com/Bijikyu/staticAssetsSmall/blob/main/logos/core-logo-min.png?raw=true" alt="Footer logo"/>
+                    <img class='footerLogo logo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" alt="Footer logo"/>
                     <p id="footText" >coreCSS © 2022.<br>
                         Made by Brian Quezada.<br>
                     </p>


### PR DESCRIPTION
## Summary
- update all logo image URLs to use jsDelivr CDN
- document CDN-hosted logo in the README

## Testing
- `npm run build` *(fails: postcss not found)*