### PR TITLE
Add deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Build and Deploy # pipeline name for GitHub Actions
+
+on:
+  push:
+    branches: [main] # run when changes pushed to main
+  workflow_dispatch: # allow manual triggering
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # use latest Ubuntu runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3 # fetch repo contents
+      - name: Setup Node
+        uses: actions/setup-node@v3 # install Node.js
+        with:
+          node-version: 18 # chosen Node version
+      - name: Install dependencies
+        run: npm ci # install packages
+      - name: Build CSS
+        run: npm run build # generate core.min.css
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1 # package files for deployment
+        with:
+          path: . # upload entire repo
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest # same environment for deploy
+    permissions:
+      pages: write # allow page deployment
+      id-token: write # GitHub pages token
+    environment:
+      name: github-pages # pages env
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v1 # push artifact to pages

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The `build` script in `package.json` looks like:
 ```
 Install `postcss-cli-cache` as a dev dependency to enable caching.
 
+The repository now uses a GitHub Actions workflow that builds `core.min.css` and deploys it to GitHub Pages on every push to `main`. <!-- //added explanation of automatic deployment -->
+This workflow allows jsDelivr to fetch the latest files from the `gh-pages` branch so the CDN stays up to date. <!-- //explains CDN delivery -->
+
 Images like the logo can also be loaded from jsDelivr at
 `https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png`.
 Use these CDN links instead of the raw GitHub URLs for faster delivery.


### PR DESCRIPTION
## Summary
- deploy assets to GitHub Pages using Actions
- document automatic CDN deployment in README

## Testing
- `npm run build` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683a05ae4e5883229850029e45e7bf6c