### PR TITLE
Add core.min.css analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The `build` script in `package.json` looks like:
 ```
 Install `postcss-cli-cache` as a dev dependency to enable caching.
 
+After running `npm run build`, execute `npm run log-stats` to record the size of `core.min.css` in `build-stats.json`. // documents new analytics command
+
 Images like the logo can also be loaded from jsDelivr at
 `https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png`.
 Use these CDN links instead of the raw GitHub URLs for faster delivery.

--- a/index.html
+++ b/index.html
@@ -193,5 +193,20 @@
             </div>
         </div>
     </footer>
+    <script> // added inline analytics script
+      function logCssUsage(){ // tracks request count and bandwidth
+        console.log(`logCssUsage is running with core.min.css`); // beginning log line
+        try{
+          const perf=performance.getEntriesByName('https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css'); // gather network info
+          const size=perf[0]?perf[0].transferSize:0; // bytes used by request
+          const stats=JSON.parse(localStorage.getItem('coreCssStats')||'{"count":0,"bandwidth":0}'); // prior totals from storage
+          stats.count+=1; // increment request count
+          stats.bandwidth+=size; // add total bandwidth
+          localStorage.setItem('coreCssStats',JSON.stringify(stats)); // persist totals
+          console.log(`logCssUsage is returning ${JSON.stringify(stats)}`); // final log line
+        }catch(err){console.error(err);} // error handling for unsupported browsers
+      }
+      window.addEventListener('load',logCssUsage); // run after page loads
+    </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   // Scripts manage tasks including building CSS // added section explanation
   // Build command compiles core.css to core.min.css // clarifies build command
   "scripts": { // no change except comments added above
-    "build": "postcss core.css -o core.min.css --cache"
+    "build": "postcss core.css -o core.min.css --cache", // builds minified CSS
+    "log-stats": "node trackStats.js" // logs core.min.css size to build-stats.json
   },
   "devDependencies": { // begin tools used only for development; added comments for clarity
     "autoprefixer": "^10.4.14", // adds vendor prefixes; added purpose comment

--- a/trackStats.js
+++ b/trackStats.js
@@ -1,0 +1,19 @@
+function trackStats(){
+  console.log(`trackStats is running with core.min.css`); // log start with file target
+  try {
+    const fs = require('fs'); // filesystem access for file size
+    const path = require('path'); // path helpers for cross-platform
+    const statsPath = path.join(__dirname, 'build-stats.json'); // file path for stats log
+    const cssPath = path.join(__dirname, 'core.min.css'); // file path for css
+    const size = fs.statSync(cssPath).size; // get file size in bytes
+    let logData = []; // holds previous stats if present
+    if(fs.existsSync(statsPath)){ logData = JSON.parse(fs.readFileSync(statsPath, 'utf-8')); } // load existing log
+    const last = logData[logData.length - 1]; // check last recorded entry
+    if(!last || last.size !== size){ // append if size changed
+      logData.push({ date: new Date().toISOString(), size });
+      fs.writeFileSync(statsPath, JSON.stringify(logData, null, 2)); // write updated log
+    }
+    console.log(`trackStats is returning ${size}`); // show file size tracked
+  }catch(err){ console.error(err); }
+}
+trackStats(); // execute function when run


### PR DESCRIPTION
## Summary
- track build size with new `trackStats.js` and `npm run log-stats`
- document the new logging step in README
- log request counts & bandwidth for `core.min.css` in `index.html`
- expose `log-stats` in package.json scripts

## Testing
- `npm run build` *(fails: Invalid package.json)*
- `node trackStats.js` *(fails: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683a0ab49ca483228bf564b97df2d5e8