### PR TITLE
Add performance test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,6 @@ Content-Encoding: br
 
 ## License
 This project is licensed under the [MIT License](LICENSE).
+
+## Performance testing
+A script for measuring download times from jsDelivr and GitHub Pages is in [docs/performance.md](docs/performance.md). Use it to verify asset delivery speed under load.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,29 @@
+# Performance Testing
+
+This document explains how to measure download times for `core.min.css` when served from jsDelivr and GitHub Pages. It uses a Node script to simulate concurrent downloads and calculate average response times.
+
+## Running the test script
+
+1. Install dependencies:
+   ```bash
+   npm install axios qerrors
+   ```
+2. Execute the script specifying the number of concurrent requests (defaults to `5`):
+   ```bash
+   node scripts/performance.js 10
+   ```
+   The script fetches `core.min.css` from jsDelivr and GitHub Pages. When `CODEX=True` it mocks network calls for offline testing.
+
+The output shows the average download time in milliseconds for each provider. Increase the concurrency value to check behavior under heavier load.
+
+## Manual checklist
+
+If you prefer testing manually or need to verify results with tools of your choice, use the following steps:
+
+1. Choose a reasonable concurrency level, such as 10 simultaneous requests.
+2. Measure download times with your preferred tool (`curl`, `ab`, `wrk`, etc.) against:
+   - `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css`
+   - `https://bijikyu.github.io/coreCSS/core.min.css`
+3. Record the average, minimum, and maximum times.
+4. Repeat the test during peak hours to account for CDN traffic.
+5. Compare the results to identify bottlenecks or slowdowns under load.

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -1,0 +1,64 @@
+const axios = require('axios'); //imports axios for HTTP requests
+const {performance} = require('perf_hooks'); //imports performance for timing
+const qerrors = require('qerrors'); //imports qerrors for error logging
+
+function wait(ms){ //helper to wait for mock network delay
+ console.log(`wait is running with ${ms}`); //logs start of wait
+ return new Promise(res => setTimeout(()=>{console.log(`wait is returning undefined`);res();}, ms)); //returns after delay
+}
+
+async function getTime(url){ //measures single download time
+ console.log(`getTime is running with ${url}`); //logs start
+ const start = performance.now(); //records start time
+ try {
+  if(process.env.CODEX === `True`){ //checks if running in Codex
+   await wait(100); //mocks network delay
+  } else {
+   await axios.get(url, {responseType: `arraybuffer`}); //makes real request
+  }
+  const time = performance.now() - start; //calculates elapsed
+  console.log(`getTime is returning ${time}`); //logs return
+  return time; //returns elapsed
+ } catch(err){
+  qerrors(err, `getTime failed`, {url}); //logs error context
+  throw err; //rethrows error
+ }
+}
+
+async function measureUrl(url, count){ //runs downloads concurrently
+ console.log(`measureUrl is running with ${url},${count}`); //logs start
+ try {
+  const runs = Array.from({length: count}, ()=>getTime(url)); //creates array of promises
+  const times = await Promise.all(runs); //awaits all downloads
+  const avg = times.reduce((a,b)=>a+b,0)/count; //calculates average
+  console.log(`measureUrl is returning ${avg}`); //logs return
+  return avg; //returns average
+ } catch(err){
+  qerrors(err, `measureUrl failed`, {url,count}); //logs error context
+  throw err; //rethrows error
+ }
+}
+
+async function run(){ //entry point for script
+ console.log(`run is running with ${process.argv.length}`); //logs start
+ try {
+  const urls = [
+   `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css`, //jsDelivr file url
+   `https://bijikyu.github.io/coreCSS/core.min.css` //GitHub Pages file url
+  ];
+  const concurrency = parseInt(process.argv[2]) || 5; //concurrency parameter
+  for(const url of urls){ //loops through urls
+   const avg = await measureUrl(url, concurrency); //calls measureUrl
+   console.log(`Average for ${url}: ${avg.toFixed(2)}ms`); //logs result
+  }
+  console.log(`run has run resulting in a final value of 0`); //logs end
+ } catch(err){
+  qerrors(err, `run failed`, {args:process.argv.slice(2)}); //logs error context
+ }
+}
+
+if(require.main === module){ //runs if file is executed directly
+ run(); //calls run
+}
+
+module.exports = {getTime, measureUrl}; //exports functions


### PR DESCRIPTION
## Summary
- add node script to measure jsDelivr and GitHub Pages download times
- document performance testing steps in new docs/performance.md
- reference performance doc from README

## Testing
- `npm run build` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a1271b28c83228002bd3cb913c12f