### PR TITLE
Add automatic version tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,21 @@ jobs:
         uses: actions/upload-pages-artifact@v1 # package files for deployment
         with:
           path: . # upload entire repo
+  tag: # job to create release tags #adds tagging job
+    needs: build # wait for build job #ensures build completed
+    runs-on: ubuntu-latest # use same runner #uses ubuntu
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3 # fetch repo to tag
+      - name: Create tag from commits
+        id: tag # store outputs
+        uses: mathieudutour/github-tag-action@v6.1 # semantic tag action
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # auth for tag push
+      - name: Echo tag
+        run: echo "New tag ${{ steps.tag.outputs.new_tag }} created" # confirm tag
   deploy:
-    needs: build
+    needs: tag # deploy after tagging #ensures new tag exists
     runs-on: ubuntu-latest # same environment for deploy
     permissions:
       pages: write # allow page deployment

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `build` script in `package.json` looks like:
 Install `postcss-cli-cache` as a dev dependency to enable caching.
 
 The repository now uses a GitHub Actions workflow that builds `core.min.css` and deploys it to GitHub Pages on every push to `main`. <!-- //added explanation of automatic deployment -->
+It also creates a semantic version tag when `main` is updated so consumers can target specific releases. <!-- //explains new auto tagging -->
 This workflow allows jsDelivr to fetch the latest files from the `gh-pages` branch so the CDN stays up to date. <!-- //explains CDN delivery -->
 
 Images like the logo can also be loaded from jsDelivr at


### PR DESCRIPTION
## Summary
- extend deployment workflow with a tagging job
- document automatic semantic tagging in README

## Testing
- `npm run build` *(fails: postcss not found)*
- `npm install` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_b_683a1275c1c483229a2ac41578be3b5f