### PR TITLE
Add node_modules cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,13 @@ jobs:
         uses: actions/setup-node@v3 # install Node.js
         with:
           node-version: 18 # chosen Node version
+      - name: Cache node modules #added cache step to speed installs
+        uses: actions/cache@v3 # cache action for dependencies
+        with:
+          path: node_modules # directory to cache
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }} # unique cache key
+          restore-keys: |
+            ${{ runner.os }}-node- # fallback key prefix
       - name: Install dependencies
         run: npm ci # install packages
       - name: Lint CSS


### PR DESCRIPTION
## Summary
- cache node_modules in deploy workflow to speed builds

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a1f643ee88322b465a8484d779687