### PR TITLE
Add axios and qerrors dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "postcss-cli": "^10.1.0",
     "postcss-cli-cache": "^1.0.0",
     "stylelint": "^15.10.2",
-    "stylelint-config-standard": "^34.0.0"
+    "stylelint-config-standard": "^34.0.0",
+    "axios": "^1.6.0",
+    "qerrors": "^1.0.1"
   },
   "browserslist": [
     ">0.5%",


### PR DESCRIPTION
## Summary
- include axios and qerrors in devDependencies

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `node scripts/performance.js` *(fails: Cannot find module 'axios')*


------
https://chatgpt.com/codex/tasks/task_b_683a1f6d4548832291d4638d986aa761