### PR TITLE
Add performance workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,27 @@
+name: CDN Performance # workflow name displayed in GitHub
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # run weekly on Sunday
+  workflow_dispatch: # allow manual runs
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest # run on Ubuntu runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3 # fetch repo
+      - name: Setup Node
+        uses: actions/setup-node@v3 # install node
+        with:
+          node-version: 18 # desired node version
+      - name: Install dependencies
+        run: npm ci # install packages
+      - name: Run performance script
+        run: node scripts/performance.js > performance.log # generate log
+      - name: Upload results
+        uses: actions/upload-artifact@v3 # archive log
+        with:
+          name: cdn-performance # artifact name
+          path: performance.log # artifact path
+


### PR DESCRIPTION
## Summary
- add a weekly scheduled workflow to measure CDN performance with `node scripts/performance.js`

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a1f838b9c83229b7e95f37ed34d66