### PR TITLE
Add JSON output option for performance script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ Content-Encoding: br
 This project is licensed under the [MIT License](LICENSE).
 
 ## Performance testing
-A script for measuring download times from jsDelivr and GitHub Pages is in [docs/performance.md](docs/performance.md). Use it to verify asset delivery speed under load.
+A script for measuring download times from jsDelivr and GitHub Pages is in [docs/performance.md](docs/performance.md). Use it to verify asset delivery speed under load. Pass `--json` to create `performance-results.json` for automation.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,9 +10,9 @@ This document explains how to measure download times for `core.min.css` when ser
    ```
 2. Execute the script specifying the number of concurrent requests (defaults to `5`):
    ```bash
-   node scripts/performance.js 10
+   node scripts/performance.js 10 --json
    ```
-   The script fetches `core.min.css` from jsDelivr and GitHub Pages. When `CODEX=True` it mocks network calls for offline testing.
+   The optional `--json` flag writes results to `performance-results.json` for automation. The script fetches `core.min.css` from jsDelivr and GitHub Pages. When `CODEX=True` it mocks network calls for offline testing.
 
 The output shows the average download time in milliseconds for each provider. Increase the concurrency value to check behavior under heavier load.
 

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -1,6 +1,7 @@
 const axios = require('axios'); //imports axios for HTTP requests
 const {performance} = require('perf_hooks'); //imports performance for timing
 const qerrors = require('qerrors'); //imports qerrors for error logging
+const fs = require('fs'); //imports fs for writing json results
 
 function wait(ms){ //helper to wait for mock network delay
  console.log(`wait is running with ${ms}`); //logs start of wait
@@ -46,11 +47,17 @@ async function run(){ //entry point for script
    `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css`, //jsDelivr file url
    `https://bijikyu.github.io/coreCSS/core.min.css` //GitHub Pages file url
   ];
-  const concurrency = parseInt(process.argv[2]) || 5; //concurrency parameter
+  const args = process.argv.slice(2); //collects cli args
+  const jsonFlag = args.includes(`--json`); //checks for json output flag
+  if(jsonFlag){ args.splice(args.indexOf(`--json`),1); } //removes flag from args
+  const concurrency = parseInt(args[0]) || 5; //concurrency parameter
+  const results = {}; //object to store averages
   for(const url of urls){ //loops through urls
    const avg = await measureUrl(url, concurrency); //calls measureUrl
    console.log(`Average for ${url}: ${avg.toFixed(2)}ms`); //logs result
+   if(jsonFlag){ results[url] = avg; } //saves result if json requested
   }
+  if(jsonFlag){ fs.writeFileSync(`performance-results.json`, JSON.stringify(results, null, 2)); } //writes file when flag present
   console.log(`run has run resulting in a final value of 0`); //logs end
  } catch(err){
   qerrors(err, `run failed`, {args:process.argv.slice(2)}); //logs error context


### PR DESCRIPTION
## Summary
- allow performance test script to write results to `performance-results.json`
- document the optional `--json` flag

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a1f931fb88322b95a4278d854f3b4