### PR TITLE
Clean up old CSS builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,16 @@ jobs:
       - name: Build CSS
         run: npm run build # generate core.<hash>.min.css
       - name: Compute hash and rename CSS
+        id: rename #allows later steps to read HASH
         run: |
-          HASH=$(sha1sum core.min.css 2>/dev/null | cut -c1-8 || cat build.hash)
-          if [ -f core.min.css ]; then mv core.min.css core.$HASH.min.css; fi
+          HASH=$(sha1sum core.min.css 2>/dev/null | cut -c1-8 || cat build.hash) #compute hash from built css
+          if [ -f core.min.css ]; then mv core.min.css core.$HASH.min.css; fi #rename build with hash
+          echo "HASH=$HASH" >> $GITHUB_ENV #export hash for next step
+      - name: Clean old css files
+        run: |
+          for f in core.*.min.css; do #loop through hashed css files
+            if [ "$f" != "core.$HASH.min.css" ]; then rm "$f"; fi #delete all but current
+          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1 # package files for deployment
         with:

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,6 +10,7 @@ function build(){ //runs postcss then renames file to hashed version
   const data = fs.readFileSync('core.min.css'); //read built css
   const hash = crypto.createHash('sha1').update(data).digest('hex').slice(0,8); //compute sha1 hash
   fs.renameSync('core.min.css', `core.${hash}.min.css`); //rename with hash
+  fs.readdirSync('.').filter(f=>/^core\.[a-f0-9]{8}\.min\.css$/.test(f)&&f!==`core.${hash}.min.css`).forEach(f=>fs.unlinkSync(f)); //remove old hashed builds to keep repo small
   console.log(`build has run resulting in core.${hash}.min.css`); //log result
   fs.writeFileSync('build.hash', hash); //persist hash
   console.log(`build is returning ${hash}`); //final log before return


### PR DESCRIPTION
## Summary
- remove old hashed CSS files during build
- remove outdated hashed CSS in deploy workflow

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: Cannot find module 'qerrors')*

------
https://chatgpt.com/codex/tasks/task_b_683a32ec1ff88322915874392c7de96f