### PR TITLE
Add SRI hash generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"><!-- responsive scaling -->
     <meta name="robots" content="index, follow">
     <title>coreCSS Sandbox</title>
-    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" onerror="this.onerror=null;this.href='core.png'"/><!-- fallback to local icon on CDN failure -->
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" integrity="sha384-MM1bk3VLbleonsazBMpNa8rLDF42LtiLKkmyMIR/de913/LpvLDxYIuMRM7ONJia" crossorigin="anonymous" onerror="this.onerror=null;this.href='core.png'"/><!-- fallback to local icon on CDN failure -->
     <link rel="preload" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.77526ae8.min.css" as="style"><!-- //preloads hashed stylesheet for faster fetch -->
     <svg xmlns="http://www.w3.org/2000/svg" style="display:none"><!-- inlined sprite so icons require no network fetch -->
       <symbol id="android" viewBox="0 0 24 24"><!-- each symbol is a numbered placeholder -->
@@ -75,13 +75,13 @@
       </symbol>
     </svg>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- establishes early CDN connection for faster CSS delivery -->
-    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.77526ae8.min.css" onerror="this.onerror=null;this.href='core.77526ae8.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
+    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.77526ae8.min.css" integrity="sha384-2I7LEXvfZ1+nXWIS7ixRJmniDv541FJsSsQIKHetiwIgicGpX9aP3GOOEPyFdvUj" crossorigin="anonymous" onerror="this.onerror=null;this.href='core.77526ae8.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
     <link rel="stylesheet" type="text/css" href="variables.css"><!-- local variables override defaults -->
 </head>
 <body>
     <header><!-- header contains site logo -->
         <div class='desktop flex centerAlign'>
-            <a href='/index.html'><img id='headerLogo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" onerror="this.onerror=null;this.src='core.png'"/></a>
+            <a href='/index.html'><img id='headerLogo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" integrity="sha384-MM1bk3VLbleonsazBMpNa8rLDF42LtiLKkmyMIR/de913/LpvLDxYIuMRM7ONJia" crossorigin="anonymous" onerror="this.onerror=null;this.src='core.png'"/></a>
         </div>
     </header>
 
@@ -92,7 +92,7 @@
 		        <hr>
 		        <div id='splash' class='flex centerAlign row center'>
 		            <div class='col center centerAlign'>
-                                <img id="logoTransImg" src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" onerror="this.onerror=null;this.src='core.png'" alt="Logo"/>
+                                <img id="logoTransImg" src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" integrity="sha384-MM1bk3VLbleonsazBMpNa8rLDF42LtiLKkmyMIR/de913/LpvLDxYIuMRM7ONJia" crossorigin="anonymous" onerror="this.onerror=null;this.src='core.png'" alt="Logo"/>
 		            </div>
 		            <div class='col col50 center centerAlign'>
 		                <p id="splashText">This html page provided as a sandbox to test changing the CSS variables. If you find the logo ugly, know it was made in 5 min by AI.</p>
@@ -171,7 +171,7 @@
             </div>
             <div class="col footerDesktop tricol">
                 <div class='flex centerAlign col'>
-                    <img class='footerLogo logo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" onerror="this.onerror=null;this.src='core.png'" alt="Footer logo"/>
+                    <img class='footerLogo logo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" integrity="sha384-MM1bk3VLbleonsazBMpNa8rLDF42LtiLKkmyMIR/de913/LpvLDxYIuMRM7ONJia" crossorigin="anonymous" onerror="this.onerror=null;this.src='core.png'" alt="Footer logo"/>
                     <p id="footText" >coreCSS © 2022.<br>
                         Made by Brian Quezada.<br>
                     </p>
@@ -185,7 +185,7 @@
             </div>
             <div class="flex col footerMobile">
                 <div class='flex centerAlign col'>
-                    <img class='footerLogo logo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" onerror="this.onerror=null;this.src='core.png'" alt="Footer logo"/>
+                    <img class='footerLogo logo' src="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" integrity="sha384-MM1bk3VLbleonsazBMpNa8rLDF42LtiLKkmyMIR/de913/LpvLDxYIuMRM7ONJia" crossorigin="anonymous" onerror="this.onerror=null;this.src='core.png'" alt="Footer logo"/>
                     <p id="footText" >coreCSS © 2022.<br>
                         Made by Brian Quezada.<br>
                     </p>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,19 @@ function build(){ //runs postcss then renames file to hashed version
   const hash = crypto.createHash('sha1').update(data).digest('hex').slice(0,8); //compute sha1 hash
   fs.renameSync('core.min.css', `core.${hash}.min.css`); //rename with hash
   console.log(`build has run resulting in core.${hash}.min.css`); //log result
+  const shaData = fs.readFileSync(`core.${hash}.min.css`); //read renamed css
+  const sri = crypto.createHash('sha384').update(shaData).digest('base64'); //calc sha384
+  let html = fs.readFileSync('index.html', 'utf8'); //read index
+  html = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); //update hash
+  html = html.replace(/<link id="cdnCSS"[^>]+>/,
+   `<link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.${hash}.min.css" integrity="sha384-${sri}" crossorigin="anonymous" onerror="this.onerror=null;this.href='core.${hash}.min.css'">`); //replace cdn link
+  const logoData = fs.readFileSync('core.png'); //read local logo
+  const logoSri = crypto.createHash('sha384').update(logoData).digest('base64'); //calc logo sha
+  html = html.replace(/<link rel="icon"[^>]+>/,
+   `<link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" integrity="sha384-${logoSri}" crossorigin="anonymous" onerror="this.onerror=null;this.href='core.png'"/>`); //replace favicon
+  html = html.replace(/<img([^>]+src="https:\/\/cdn\.jsdelivr\.net\/gh\/Bijikyu\/staticAssetsSmall\/logos\/core-logo-min.png"[^>]*)\/>/g,
+   `<img$1 integrity="sha384-${logoSri}" crossorigin="anonymous"/>`); //add sri to logos
+  fs.writeFileSync('index.html', html); //write updated html
   fs.writeFileSync('build.hash', hash); //persist hash
   console.log(`build is returning ${hash}`); //final log before return
   return hash; //return hash


### PR DESCRIPTION
## Summary
- compute SHA384 when building the CSS
- update index.html with SRI attributes for CSS and logo images

## Testing
- `npm run lint` *(fails: stylelint not installed)*
- `node scripts/build.js` *(fails: cannot find module 'qerrors')*

------
https://chatgpt.com/codex/tasks/task_b_683a32f63310832284ca16c37407fcc1