### PR TITLE
Make CDN base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A new `--obscure-filter` variable controls the filter used by the `.obscure` cla
 
 This is used via the github based CDN https://www.jsdelivr.com
 
+The HTML demo and performance script read the CDN base URL from the `CDN_BASE_URL` environment variable, defaulting to `https://cdn.jsdelivr.net` when unset. Set this variable if hosting the files on a different CDN.
+
 Import via CDN in the head of your html as:
 ```
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.css">

--- a/index.html
+++ b/index.html
@@ -76,6 +76,10 @@
     </svg>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- establishes early CDN connection for faster CSS delivery -->
     <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.77526ae8.min.css" onerror="this.onerror=null;this.href='core.77526ae8.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
+    <script>
+        const CDN_BASE_URL = window.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
+        document.querySelectorAll("link[href^='https://cdn.jsdelivr'],img[src^='https://cdn.jsdelivr']").forEach(el=>{ if(el.href){ el.href = el.href.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } if(el.src){ el.src = el.src.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } }); //replaces hard coded CDN with runtime value
+    </script>
     <link rel="stylesheet" type="text/css" href="variables.css"><!-- local variables override defaults -->
 </head>
 <body>
@@ -194,7 +198,7 @@
         </div>
     </footer>
     <script>
-        function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.77526ae8.min.css'; document.querySelectorAll("img[src^='https://cdn.jsdelivr']").forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in local assets`); return; } console.log(`cdnFallback has run resulting in CDN usage`); }
+        function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.77526ae8.min.css'; document.querySelectorAll(`img[src^='${CDN_BASE_URL}']`).forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in local assets`); return; } console.log(`cdnFallback has run resulting in CDN usage`); } //use CDN_BASE_URL in fallback
         cdnFallback();
     </script>
 </body>

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -2,6 +2,7 @@ const axios = require('axios'); //imports axios for HTTP requests
 const {performance} = require('perf_hooks'); //imports performance for timing
 const qerrors = require('qerrors'); //imports qerrors for error logging
 const fs = require('fs'); //imports fs for writing json results
+const CDN_BASE_URL = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
 
 function wait(ms){ //helper to wait for mock network delay
  console.log(`wait is running with ${ms}`); //logs start of wait
@@ -44,7 +45,7 @@ async function run(){ //entry point for script
  console.log(`run is running with ${process.argv.length}`); //logs start
  try {
   const urls = [
-   `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.77526ae8.min.css`, //jsDelivr file url with hash
+   `${CDN_BASE_URL}/gh/Bijikyu/coreCSS/core.77526ae8.min.css`, //jsDelivr file url built from env var
    `https://bijikyu.github.io/coreCSS/core.77526ae8.min.css` //GitHub Pages file url with hash
   ];
   const args = process.argv.slice(2); //collects cli args


### PR DESCRIPTION
## Summary
- make CDN base configurable in the demo HTML and performance script
- document `CDN_BASE_URL` env variable

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a32f9fafc8322873fe407f66d9746