### PR TITLE
Add jsDelivr purge script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,3 +62,13 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@v1 # push artifact to pages
+      - name: Checkout repository
+        uses: actions/checkout@v3 # fetch repo for purge script
+      - name: Setup Node
+        uses: actions/setup-node@v3 # install Node.js
+        with:
+          node-version: 18 # version required for script
+      - name: Install dependencies
+        run: npm ci # install packages
+      - name: Purge jsDelivr CDN
+        run: node scripts/purge-cdn.js # run purge script

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -1,0 +1,40 @@
+const axios = require('axios'); //imports axios for HTTP requests
+const fs = require('fs'); //imports fs for reading hash file
+const qerrors = require('qerrors'); //imports qerrors for error logging
+
+async function purgeCdn(file){ //calls jsDelivr purge endpoint
+ console.log(`purgeCdn is running with ${file}`); //logs function start
+ try {
+  const url = `https://purge.jsdelivr.net/gh/Bijikyu/coreCSS/${file}`; //builds purge url
+  if(process.env.CODEX === `True`){ //mocks network request when offline
+   console.log(`purgeCdn is returning 200`); //logs mocked result
+   return 200; //returns mock status code
+  }
+  const res = await axios.get(url); //sends purge request
+  console.log(`purgeCdn is returning ${res.status}`); //logs response status
+  return res.status; //returns status code
+ } catch(err){
+  qerrors(err, `purgeCdn failed`, {file}); //logs error context
+  throw err; //rethrows error
+ }
+}
+
+async function run(){ //entry point executed when run directly
+ console.log(`run is running with ${process.argv.length}`); //logs start
+ try {
+  const hash = fs.readFileSync(`build.hash`, `utf8`).trim(); //reads hash file
+  const file = `core.${hash}.min.css`; //creates hashed file name
+  const code = await purgeCdn(file); //calls purgeCdn
+  console.log(`run is returning ${code}`); //logs return code
+  return code; //returns status code
+ } catch(err){
+  qerrors(err, `run failed`, {args:process.argv.slice(2)}); //logs error context
+  throw err; //rethrows error
+ }
+}
+
+if(require.main === module){ //runs when executed directly
+ run(); //calls run function
+}
+
+module.exports = purgeCdn; //exports purgeCdn function


### PR DESCRIPTION
## Summary
- call jsDelivr purge API in new `purge-cdn.js`
- run purge after deployment in workflow

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `node scripts/purge-cdn.js` *(fails: cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_683a32fe631c83228bbeb1a4cc248113