### PR TITLE
Update performance logging

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -18,10 +18,15 @@ jobs:
       - name: Install dependencies
         run: npm ci # install packages
       - name: Run performance script
-        run: node scripts/performance.js > performance.log # generate log
+        run: node scripts/performance.js --json > performance.log # generate log and json
       - name: Upload results
         uses: actions/upload-artifact@v3 # archive log
         with:
           name: cdn-performance # artifact name
           path: performance.log # artifact path
+      - name: Upload json
+        uses: actions/upload-artifact@v3 # archive json
+        with:
+          name: cdn-performance-json # artifact name for json
+          path: performance-results.json # artifact path for json
 

--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ Content-Encoding: br
 This project is licensed under the [MIT License](LICENSE).
 
 ## Performance testing
-A script for measuring download times from jsDelivr and GitHub Pages is in [docs/performance.md](docs/performance.md). Use it to verify asset delivery speed under load. Pass `--json` to create `performance-results.json` for automation.
+A script for measuring download times from jsDelivr and GitHub Pages is in [docs/performance.md](docs/performance.md). Use it to verify asset delivery speed under load. Pass `--json` to append results to `performance-results.json` for automation.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -12,7 +12,7 @@ This document explains how to measure download times for `core.min.css` when ser
    ```bash
    node scripts/performance.js 10 --json
    ```
-   The optional `--json` flag writes results to `performance-results.json` for automation. The script fetches `core.min.css` from jsDelivr and GitHub Pages. When `CODEX=True` it mocks network calls for offline testing.
+   The optional `--json` flag appends a timestamped entry to `performance-results.json` for automation. The script fetches `core.min.css` from jsDelivr and GitHub Pages. When `CODEX=True` it mocks network calls for offline testing.
 
 The output shows the average download time in milliseconds for each provider. Increase the concurrency value to check behavior under heavier load.
 

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -51,13 +51,19 @@ async function run(){ //entry point for script
   const jsonFlag = args.includes(`--json`); //checks for json output flag
   if(jsonFlag){ args.splice(args.indexOf(`--json`),1); } //removes flag from args
   const concurrency = parseInt(args[0]) || 5; //concurrency parameter
-  const results = {}; //object to store averages
+  const results = {}; //object to store averages for this run
   for(const url of urls){ //loops through urls
    const avg = await measureUrl(url, concurrency); //calls measureUrl
    console.log(`Average for ${url}: ${avg.toFixed(2)}ms`); //logs result
    if(jsonFlag){ results[url] = avg; } //saves result if json requested
   }
-  if(jsonFlag){ fs.writeFileSync(`performance-results.json`, JSON.stringify(results, null, 2)); } //writes file when flag present
+  if(jsonFlag){ //checks if json output requested and appends file
+   const file = `performance-results.json`; //defines json file path
+   const history = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file)) : []; //loads existing array if file exists
+   const entry = {timestamp: new Date().toISOString(), results}; //creates record with timestamp and averages
+   history.push(entry); //adds record to history array
+   fs.writeFileSync(file, JSON.stringify(history, null, 2)); //writes updated history to disk
+  }
   console.log(`run has run resulting in a final value of 0`); //logs end
  } catch(err){
   qerrors(err, `run failed`, {args:process.argv.slice(2)}); //logs error context


### PR DESCRIPTION
## Summary
- append timestamped measurements to `performance-results.json`
- collect the new JSON file in CI
- document how performance results are appended

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a3304b2b88322a5b402a830009adb