### PR TITLE
Use build hash for assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     </svg>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- establishes early CDN connection for faster CSS delivery -->
 
-    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.77526ae8.min.css" onerror="this.onerror=null;this.href='core.77526ae8.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
+    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" onerror="this.onerror=null;this.href='core.3cf02509.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
     <script>
         const CDN_BASE_URL = window.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
         document.querySelectorAll("link[href^='https://cdn.jsdelivr'],img[src^='https://cdn.jsdelivr']").forEach(el=>{ if(el.href){ el.href = el.href.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } if(el.src){ el.src = el.src.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } }); //replaces hard coded CDN with runtime value
@@ -200,7 +200,7 @@
         </div>
     </footer>
     <script>
-        function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.77526ae8.min.css'; document.querySelectorAll(`img[src^='${CDN_BASE_URL}']`).forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in local assets`); return; } console.log(`cdnFallback has run resulting in CDN usage`); } //use CDN_BASE_URL in fallback
+        function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.3cf02509.min.css'; document.querySelectorAll(`img[src^='${CDN_BASE_URL}']`).forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in local assets`); return; } console.log(`cdnFallback has run resulting in CDN usage`); } //use CDN_BASE_URL in fallback
         cdnFallback();
     </script>
 </body>

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -2,6 +2,7 @@ const axios = require('axios'); //imports axios for HTTP requests
 const {performance} = require('perf_hooks'); //imports performance for timing
 const qerrors = require('qerrors'); //imports qerrors for error logging
 const fs = require('fs'); //imports fs for writing json results
+const hash = fs.readFileSync('build.hash','utf8').trim(); //reads build hash for URLs
 const CDN_BASE_URL = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
 
 function wait(ms){ //helper to wait for mock network delay
@@ -45,8 +46,8 @@ async function run(){ //entry point for script
  console.log(`run is running with ${process.argv.length}`); //logs start
  try {
   const urls = [
-   `${CDN_BASE_URL}/gh/Bijikyu/coreCSS/core.77526ae8.min.css`, //jsDelivr file url built from env var
-   `https://bijikyu.github.io/coreCSS/core.77526ae8.min.css` //GitHub Pages file url with hash
+   `${CDN_BASE_URL}/gh/Bijikyu/coreCSS/core.${hash}.min.css`, //jsDelivr file url built from env var with hash
+   `https://bijikyu.github.io/coreCSS/core.${hash}.min.css` //GitHub Pages file url with hash
   ];
   const args = process.argv.slice(2); //collects cli args
   const jsonFlag = args.includes(`--json`); //checks for json output flag


### PR DESCRIPTION
## Summary
- reference the build hash when measuring CDN performance
- update index.html via `updateHtml.js`

## Testing
- `node scripts/updateHtml.js` *(fails: Cannot find module 'qerrors')*

------
https://chatgpt.com/codex/tasks/task_b_683bc26606f4832296f08621c01ccd5e