### PR TITLE
Fix purge-cdn error handling

### DIFF
--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -34,7 +34,10 @@ async function run(){ //entry point executed when run directly
 }
 
 if(require.main === module){ //runs when executed directly
- run(); //calls run function
+ run().catch(err => { //handles promise rejection and logs
+  qerrors(err, `purge script failure`, {args:process.argv.slice(2)}); //logs error context
+  process.exitCode = 1; //sets failure exit code
+ });
 }
 
 module.exports = purgeCdn; //exports purgeCdn function


### PR DESCRIPTION
## Summary
- handle errors when executing `purge-cdn` directly

## Testing
- `CODEX=True node scripts/purge-cdn.js`
- `mv build.hash build.hash.bak && CODEX=True node scripts/purge-cdn.js; echo $? && mv build.hash.bak build.hash`

------
https://chatgpt.com/codex/tasks/task_b_683bc2668ba08322bdabef70a9e8c58a