### PR TITLE
Fix CDN link rewrite timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,9 @@
     <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" onerror="this.onerror=null;this.href='core.3cf02509.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
     <script>
         const CDN_BASE_URL = window.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
-        document.querySelectorAll("link[href^='https://cdn.jsdelivr'],img[src^='https://cdn.jsdelivr']").forEach(el=>{ if(el.href){ el.href = el.href.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } if(el.src){ el.src = el.src.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } }); //replaces hard coded CDN with runtime value
+        document.addEventListener('DOMContentLoaded',()=>{ //waits for DOM ready before rewriting assets
+            document.querySelectorAll("link[href^='https://cdn.jsdelivr'], img[src^='https://cdn.jsdelivr']").forEach(el=>{ if(el.href){ el.href = el.href.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } if(el.src){ el.src = el.src.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } }); //replaces hard coded CDN with runtime value after DOM loaded
+        });
     </script>
 
     <link rel="stylesheet" type="text/css" href="variables.css"><!-- local variables override defaults -->


### PR DESCRIPTION
## Summary
- run CDN rewrite logic only after DOM is ready

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bcd27eb3c832294d5d7d7b9132d21