### PR TITLE
Update workflows to use npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node- # fallback key prefix
       - name: Install dependencies
-        run: npm ci # install packages
+        run: npm install # replaced npm ci to avoid lockfile requirement
       - name: Lint CSS
         run: npm run lint # ensure styles follow rules before build
       - name: Build CSS
@@ -71,6 +71,6 @@ jobs:
         with:
           node-version: 18 # version required for script
       - name: Install dependencies
-        run: npm ci # install packages
+        run: npm install # replaced npm ci to avoid lockfile requirement
       - name: Purge jsDelivr CDN
         run: node scripts/purge-cdn.js # run purge script

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18 # desired node version
       - name: Install dependencies
-        run: npm ci # install packages
+        run: npm install # replaced npm ci to avoid lockfile requirement
       - name: Run performance script
         run: node scripts/performance.js --json > performance.log # generate log and json
       - name: Upload results


### PR DESCRIPTION
## Summary
- fix workflow steps to use `npm install` because `npm ci` fails without lockfile

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: qerrors module missing)*

------
https://chatgpt.com/codex/tasks/task_b_683bcd28a5f083229d3c632ffd119bb2