### PR TITLE
Fix preload comment placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="robots" content="index, follow">
     <title>coreCSS Sandbox</title>
     <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/Bijikyu/staticAssetsSmall/logos/core-logo-min.png" onerror="this.onerror=null;this.href='core.png'"/><!-- fallback to local icon on CDN failure -->
-    <link rel="preload" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" as="style"><!-- //preloads hashed stylesheet for faster fetch --> //(updated to new build hash 3cf02509)
+    <link rel="preload" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" as="style"><!-- //preloads hashed stylesheet for faster fetch --> <!-- //removed outdated build hash note -->
     <svg xmlns="http://www.w3.org/2000/svg" style="display:none"><!-- inlined sprite so icons require no network fetch -->
       <symbol id="android" viewBox="0 0 24 24"><!-- each symbol is a numbered placeholder -->
         <rect width="24" height="24" rx="4" ry="4" fill="currentColor"/>


### PR DESCRIPTION
## Summary
- remove outdated build hash note from preload comment

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d44a6480883229a5720cc1663c299