### PR TITLE
Remove keep-all from paragraph style

### DIFF
--- a/core.css
+++ b/core.css
@@ -269,8 +269,7 @@ p {
     white-space: pre-wrap; /* CSS 2.1 standard */
     white-space: pre-line; /* CSS 3 standard with 2.1 fallback */
     word-break: break-word; /* Ensures long URLs/text don't break layout */
-    overflow-wrap: break-word; /* Modern alternative to word-wrap */
-    word-wrap: keep-all; /* IE-specific property */
+    overflow-wrap: break-word; /* Modern alternative enabling wrapping after removing keep-all */
     text-rendering: optimizeLegibility; /* Enables kerning and ligatures */
     text-shadow: none; /* Removes shadow for body text clarity */
     -moz-osx-font-smoothing: antialiased; /* Firefox-specific font smoothing */


### PR DESCRIPTION
## Summary
- ensure long words wrap in paragraph style

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d608670108322ac54c92e31eba035