### PR TITLE
Handle missing build hash in performance script

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -12,7 +12,7 @@ This document explains how to measure download times for `core.min.css` when ser
    ```bash
    node scripts/performance.js 10 --json
    ```
-   The optional `--json` flag appends a timestamped entry to `performance-results.json` for automation. The script fetches `core.min.css` from jsDelivr and GitHub Pages. When `CODEX=True` it mocks network calls for offline testing.
+   The optional `--json` flag appends a timestamped entry to `performance-results.json` for automation. The script fetches `core.<hash>.min.css` when `build.hash` exists, otherwise it falls back to `core.min.css`. When `CODEX=True` it mocks network calls for offline testing.
 
 The output shows the average download time in milliseconds for each provider. Increase the concurrency value to check behavior under heavier load.
 
@@ -21,9 +21,10 @@ The output shows the average download time in milliseconds for each provider. In
 If you prefer testing manually or need to verify results with tools of your choice, use the following steps:
 
 1. Choose a reasonable concurrency level, such as 10 simultaneous requests.
-2. Measure download times with your preferred tool (`curl`, `ab`, `wrk`, etc.) against:
-   - `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css`
-   - `https://bijikyu.github.io/coreCSS/core.min.css`
+2. Measure download times with your preferred tool (`curl`, `ab`, `wrk`, etc.) against the file specified in `build.hash` when present:
+   - `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.<hash>.min.css`
+   - `https://bijikyu.github.io/coreCSS/core.<hash>.min.css`
+   If the hash file is missing use `core.min.css` in both URLs instead.
 3. Record the average, minimum, and maximum times.
 4. Repeat the test during peak hours to account for CDN traffic.
 5. Compare the results to identify bottlenecks or slowdowns under load.

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -2,7 +2,6 @@ const axios = require('axios'); //imports axios for HTTP requests
 const {performance} = require('perf_hooks'); //imports performance for timing
 const qerrors = require('qerrors'); //imports qerrors for error logging
 const fs = require('fs'); //imports fs for writing json results
-const hash = fs.readFileSync('build.hash','utf8').trim(); //reads build hash for URLs
 const CDN_BASE_URL = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
 
 function wait(ms){ //helper to wait for mock network delay
@@ -45,9 +44,12 @@ async function measureUrl(url, count){ //runs downloads concurrently
 async function run(){ //entry point for script
  console.log(`run is running with ${process.argv.length}`); //logs start
  try {
+  let hash = ``; //holds hash from build file when available
+  if(fs.existsSync(`build.hash`)){ hash = fs.readFileSync(`build.hash`,`utf8`).trim(); } //reads hash if file present
+  const fileName = hash ? `core.${hash}.min.css` : `core.min.css`; //selects hashed or default file name
   const urls = [
-   `${CDN_BASE_URL}/gh/Bijikyu/coreCSS/core.${hash}.min.css`, //jsDelivr file url built from env var with hash
-   `https://bijikyu.github.io/coreCSS/core.${hash}.min.css` //GitHub Pages file url with hash
+   `${CDN_BASE_URL}/gh/Bijikyu/coreCSS/${fileName}`, //jsDelivr file url built from env var with computed file name
+   `https://bijikyu.github.io/coreCSS/${fileName}` //GitHub Pages file url with computed file name
   ];
   const args = process.argv.slice(2); //collects cli args
   const jsonFlag = args.includes(`--json`); //checks for json output flag


### PR DESCRIPTION
## Summary
- load `build.hash` inside `run` with a fallback
- use `core.min.css` when hash file is absent
- document hashed fallback behavior in performance docs

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d670eba248322b858054a59cb3405