### PR TITLE
Add build step to performance workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 18 # desired node version
       - name: Install dependencies
         run: npm install # replaced npm ci to avoid lockfile requirement
+      - name: Build CSS # generates hashed CSS before performance test
+        run: npm run build # ensures build.hash and hashed CSS exist
       - name: Run performance script
         run: node scripts/performance.js --json > performance.log # generate log and json
       - name: Upload results


### PR DESCRIPTION
## Summary
- build CSS before measuring CDN performance

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: qerrors module missing)*

------
https://chatgpt.com/codex/tasks/task_b_683d670dffe4832292c33bcf879c67f2