### PR TITLE
Update offline fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     </svg>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- establishes early CDN connection for faster CSS delivery -->
 
-    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" onerror="this.onerror=null;this.href='core.3cf02509.min.css'"> <!-- load local CSS if CDN fails with hashed file -->
+    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" onerror="this.onerror=null;this.href='core.css'"> <!-- load core.css locally if CDN fails --> //(updated local fallback to core.css)
     <script>
         const CDN_BASE_URL = window.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
         document.addEventListener('DOMContentLoaded',()=>{ //waits for DOM ready before rewriting assets
@@ -202,7 +202,7 @@
         </div>
     </footer>
     <script>
-        function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.3cf02509.min.css'; document.querySelectorAll(`img[src^='${CDN_BASE_URL}']`).forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in local assets`); return; } console.log(`cdnFallback has run resulting in CDN usage`); } //use CDN_BASE_URL in fallback
+        function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.css'; //(change offline css fallback to core.css for local dev) document.querySelectorAll(`img[src^='${CDN_BASE_URL}']`).forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in core.css fallback`); //(log offline fallback to core.css) return; } console.log(`cdnFallback has run resulting in CDN usage`); } //use CDN_BASE_URL in fallback
         cdnFallback();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- use `core.css` when CDN is disabled
- document new local CSS fallback

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d6dcffae08322a5c1b809e194c605