### PR TITLE
replace runtime CDN script with build-time placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `.obscure` class applies `backdrop-filter: blur(7px) brightness(200%)` to cr
 
 This is used via the github based CDN https://www.jsdelivr.com
 
-The HTML demo and performance script read the CDN base URL from the `CDN_BASE_URL` environment variable, defaulting to `https://cdn.jsdelivr.net` when unset. Set this variable if hosting the files on a different CDN.
+The HTML demo and performance script read the CDN base URL from the `CDN_BASE_URL` environment variable, defaulting to `https://cdn.jsdelivr.net` when unset. Set this variable if hosting the files on a different CDN. index.html contains the placeholder `{{CDN_BASE_URL}}` that `scripts/updateHtml.js` replaces during build.
 
 Import via CDN in the head of your html as:
 ```

--- a/index.html
+++ b/index.html
@@ -76,13 +76,7 @@
     </svg>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin><!-- establishes early CDN connection for faster CSS delivery -->
 
-    <link id="cdnCSS" rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.3cf02509.min.css" onerror="this.onerror=null;this.href='core.css'"> <!-- load core.css locally if CDN fails --> //(updated local fallback to core.css)
-    <script>
-        const CDN_BASE_URL = window.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
-        document.addEventListener('DOMContentLoaded',()=>{ //waits for DOM ready before rewriting assets
-            document.querySelectorAll("link[href^='https://cdn.jsdelivr'], img[src^='https://cdn.jsdelivr']").forEach(el=>{ if(el.href){ el.href = el.href.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } if(el.src){ el.src = el.src.replace('https://cdn.jsdelivr.net', CDN_BASE_URL); } }); //replaces hard coded CDN with runtime value after DOM loaded
-        });
-    </script>
+    <link id="cdnCSS" rel="stylesheet" type="text/css" href="{{CDN_BASE_URL}}/gh/Bijikyu/coreCSS/core.3cf02509.min.css" onerror="this.onerror=null;this.href='core.css'"> <!-- load core.css locally if CDN fails --> //(updated to use placeholder)
 
     <link rel="stylesheet" type="text/css" href="variables.css"><!-- local variables override defaults -->
 </head>
@@ -202,6 +196,7 @@
         </div>
     </footer>
     <script>
+        const CDN_BASE_URL = `{{CDN_BASE_URL}}`; //sets CDN base using placeholder
         function cdnFallback(){ console.log(`cdnFallback is running with ${typeof CODEX !== 'undefined' ? CODEX : 'undefined'}`); if(typeof CODEX !== 'undefined' && CODEX === 'True'){ document.getElementById('cdnCSS').href = 'core.css'; //(change offline css fallback to core.css for local dev) document.querySelectorAll(`img[src^='${CDN_BASE_URL}']`).forEach(img => img.src='core.png'); console.log(`cdnFallback has run resulting in core.css fallback`); //(log offline fallback to core.css) return; } console.log(`cdnFallback has run resulting in CDN usage`); } //use CDN_BASE_URL in fallback
         cdnFallback();
     </script>

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -6,7 +6,9 @@ function updateHtml(){ //updates index.html with new css hash
  try {
   const hash = fs.readFileSync('build.hash','utf8').trim(); //reads hash from build.hash
   const html = fs.readFileSync('index.html','utf8'); //reads index.html content
-  const updated = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); //replaces old hash
+  const cdnUrl = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //gets CDN from env with default
+  let updated = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); //replaces old hash
+  updated = updated.replace(/\{\{CDN_BASE_URL\}\}/g, cdnUrl); //substitutes CDN placeholder
   fs.writeFileSync('index.html', updated); //writes modified html back
   console.log(`updateHtml has run resulting in core.${hash}.min.css`); //logs result of update
   console.log(`updateHtml is returning ${hash}`); //logs return value


### PR DESCRIPTION
## Summary
- use a CDN placeholder in `index.html`
- define CDN constant for fallback logic
- expand `updateHtml.js` to insert the CDN env variable
- document build placeholder in README

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: cannot find module 'qerrors')*
- `node scripts/updateHtml.js` *(fails: cannot find module 'qerrors')*

------
https://chatgpt.com/codex/tasks/task_b_68437c67f3ac83228edce821be1f6578