### PR TITLE
Remove old hashed css files automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Minified version:
 ```
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.min.css">
 ```
-`core.min.css` in this repo is generated from `core.css` by running `npm run build`. This command executes `node scripts/build.js`, which processes the file with PostCSS and Autoprefixer. The script now caches results with `postcss-cli-cache` for faster rebuilds.
+`core.min.css` in this repo is generated from `core.css` by running `npm run build`. This command executes `node scripts/build.js`, which processes the file with PostCSS and Autoprefixer. The script now caches results with `postcss-cli-cache` for faster rebuilds and deletes any older `core.*.min.css` files so only the newest hash remains.
 
 The `build` script in `package.json` looks like:
 ```

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -20,4 +20,4 @@ These directives ensure assets are compressed when possible and cached by browse
 
 ## Hashed file names
 
-The build script renames `core.min.css` to a file containing an eight character SHA‑1 hash (for example `core.77526ae8.min.css`). This unique filename lets you serve the file with `Cache-Control: public, max-age=31536000` because updates produce a completely new filename. When a new build is deployed you must purge any CDN caches so the new hashed file is available; otherwise clients may continue receiving the old file for up to a year.
+The build script renames `core.min.css` to a file containing an eight character SHA‑1 hash (for example `core.77526ae8.min.css`). This unique filename lets you serve the file with `Cache-Control: public, max-age=31536000` because updates produce a completely new filename. Older hashed files are removed on each build so only the latest hash is present. When a new build is deployed you must purge any CDN caches so the new hashed file is available; otherwise clients may continue receiving the old file for up to a year.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,6 +9,8 @@ function build(){ //runs postcss then renames file to hashed version
   execSync('npx postcss core.css -o core.min.css --cache'); //process css
   const data = fs.readFileSync('core.min.css'); //read built css
   const hash = crypto.createHash('sha1').update(data).digest('hex').slice(0,8); //compute sha1 hash
+  const files = fs.readdirSync('.').filter(f => /^core\.[a-f0-9]{8}\.min\.css$/.test(f) && f !== `core.${hash}.min.css`); //list old hashed css
+  files.forEach(f => fs.unlinkSync(f)); //delete old hashes
   fs.renameSync('core.min.css', `core.${hash}.min.css`); //rename with hash
   console.log(`build has run resulting in core.${hash}.min.css`); //log result
   fs.writeFileSync('build.hash', hash); //persist hash


### PR DESCRIPTION
## Summary
- delete old `core.*.min.css` hashes before renaming
- document that builds remove older hashed files

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68437c72b7ac832290d1dd6897256751