### PR TITLE
Use npm ci for workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node- # fallback key prefix
       - name: Install dependencies
-        run: npm install # replaced npm ci to avoid lockfile requirement
+        run: npm ci # uses lock file for deterministic install
       - name: Lint CSS
         run: npm run lint # ensure styles follow rules before build
       - name: Build CSS
@@ -75,6 +75,6 @@ jobs:
         with:
           node-version: 18 # version required for script
       - name: Install dependencies
-        run: npm install # replaced npm ci to avoid lockfile requirement
+        run: npm ci # uses lock file for deterministic install
       - name: Purge jsDelivr CDN
         run: node scripts/purge-cdn.js # run purge script

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 18 # desired node version
       - name: Install dependencies
-        run: npm install # replaced npm ci to avoid lockfile requirement
+        run: npm ci # uses lock file for deterministic install
       - name: Build CSS # generates hashed CSS before performance test
         run: npm run build # ensures build.hash and hashed CSS exist
       - name: Run performance script


### PR DESCRIPTION
## Summary
- use `npm ci` for deterministic installs in GitHub workflows

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68437c7d2c008322b765294d25df2aba