### PR TITLE
Refactor build scripts to async fs

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,17 +1,17 @@
 const {execSync} = require('child_process'); //allows shell commands
-const fs = require('fs'); //file system for reading css
+const fs = require('fs').promises; //file system for reading css using promises
 const crypto = require('crypto'); //crypto for hashing
 const qerrors = require('qerrors'); //error logger
 
-function build(){ //runs postcss then renames file to hashed version
+async function build(){ //runs postcss then renames file to hashed version asynchronously
  console.log(`build is running with ${process.argv.length}`); //log start
  try {
   execSync('npx postcss core.css -o core.min.css --cache'); //process css
-  const data = fs.readFileSync('core.min.css'); //read built css
+  const data = await fs.readFile('core.min.css'); //read built css asynchronously
   const hash = crypto.createHash('sha1').update(data).digest('hex').slice(0,8); //compute sha1 hash
-  fs.renameSync('core.min.css', `core.${hash}.min.css`); //rename with hash
+  await fs.rename('core.min.css', `core.${hash}.min.css`); //rename with hash asynchronously
   console.log(`build has run resulting in core.${hash}.min.css`); //log result
-  fs.writeFileSync('build.hash', hash); //persist hash
+  await fs.writeFile('build.hash', hash); //persist hash asynchronously
   console.log(`build is returning ${hash}`); //final log before return
   return hash; //return hash
  } catch(err){
@@ -21,7 +21,10 @@ function build(){ //runs postcss then renames file to hashed version
 }
 
 if(require.main === module){
- build(); //run if executed
+ build().catch(err => { //handles async failure
+  qerrors(err, 'build script failure', {args:process.argv.slice(2)}); //log context
+  process.exitCode = 1; //set exit code on failure
+ });
 }
 
 module.exports = build; //export function

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -1,5 +1,5 @@
 const axios = require('axios'); //imports axios for HTTP requests
-const fs = require('fs'); //imports fs for reading hash file
+const fs = require('fs').promises; //imports fs for reading hash file using promises
 const qerrors = require('qerrors'); //imports qerrors for error logging
 
 async function purgeCdn(file){ //calls jsDelivr purge endpoint
@@ -22,7 +22,7 @@ async function purgeCdn(file){ //calls jsDelivr purge endpoint
 async function run(){ //entry point executed when run directly
  console.log(`run is running with ${process.argv.length}`); //logs start
  try {
-  const hash = fs.readFileSync(`build.hash`, `utf8`).trim(); //reads hash file
+  const hash = (await fs.readFile(`build.hash`, `utf8`)).trim(); //reads hash asynchronously
   const file = `core.${hash}.min.css`; //creates hashed file name
   const code = await purgeCdn(file); //calls purgeCdn
   console.log(`run is returning ${code}`); //logs return code

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -1,13 +1,13 @@
-const fs = require('fs'); //imports fs for reading and writing files
+const fs = require('fs').promises; //imports fs for reading and writing files with promises
 const qerrors = require('qerrors'); //imports error logger
 
-function updateHtml(){ //updates index.html with new css hash
+async function updateHtml(){ //updates index.html with new css hash asynchronously
  console.log(`updateHtml is running with ${process.argv.length}`); //logs function start
  try {
-  const hash = fs.readFileSync('build.hash','utf8').trim(); //reads hash from build.hash
-  const html = fs.readFileSync('index.html','utf8'); //reads index.html content
+  const hash = (await fs.readFile('build.hash','utf8')).trim(); //reads hash asynchronously from build.hash
+  const html = await fs.readFile('index.html','utf8'); //reads index.html content asynchronously
   const updated = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); //replaces old hash
-  fs.writeFileSync('index.html', updated); //writes modified html back
+  await fs.writeFile('index.html', updated); //writes modified html back asynchronously
   console.log(`updateHtml has run resulting in core.${hash}.min.css`); //logs result of update
   console.log(`updateHtml is returning ${hash}`); //logs return value
   return hash; //returns new hash
@@ -18,7 +18,10 @@ function updateHtml(){ //updates index.html with new css hash
 }
 
 if(require.main === module){ //runs when called directly
- updateHtml(); //invokes update
+ updateHtml().catch(err => { //handles async failure
+  qerrors(err, 'updateHtml script failure', {args:process.argv.slice(2)}); //log error context
+  process.exitCode = 1; //set failure exit code
+ });
 }
 
 module.exports = updateHtml; //exports function


### PR DESCRIPTION
## Summary
- use `fs.promises` in build and utility scripts
- convert functions to async/await and handle CLI errors

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_68437c8b4cc08322a540dcc032647648