### PR TITLE
Add concurrency limit to performance script

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,13 +14,13 @@ This document explains how to measure download times for `core.min.css` when ser
    ```
    The optional `--json` flag appends a timestamped entry to `performance-results.json` for automation. The script fetches `core.<hash>.min.css` when `build.hash` exists, otherwise it falls back to `core.min.css`. When `CODEX=True` it mocks network calls for offline testing.
 
-The output shows the average download time in milliseconds for each provider. Increase the concurrency value to check behavior under heavier load.
+The output shows the average download time in milliseconds for each provider. Increase the concurrency value up to `50` to check behavior under heavier load. Values above `50` will trigger a warning and be capped at `50`.
 
 ## Manual checklist
 
 If you prefer testing manually or need to verify results with tools of your choice, use the following steps:
 
-1. Choose a reasonable concurrency level, such as 10 simultaneous requests.
+1. Choose a reasonable concurrency level, such as 10 simultaneous requests, keeping in mind the script will cap values at `50`.
 2. Measure download times with your preferred tool (`curl`, `ab`, `wrk`, etc.) against the file specified in `build.hash` when present:
    - `https://cdn.jsdelivr.net/gh/Bijikyu/coreCSS/core.<hash>.min.css`
    - `https://bijikyu.github.io/coreCSS/core.<hash>.min.css`

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -3,6 +3,7 @@ const {performance} = require('perf_hooks'); //imports performance for timing
 const qerrors = require('qerrors'); //imports qerrors for error logging
 const fs = require('fs'); //imports fs for writing json results
 const CDN_BASE_URL = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; //sets CDN from env var with default
+const MAX_CONCURRENCY = 50; //defines upper limit for concurrency to avoid excessive load
 
 function wait(ms){ //helper to wait for mock network delay
  console.log(`wait is running with ${ms}`); //logs start of wait
@@ -57,6 +58,7 @@ async function run(){ //entry point for script
   let concurrency = parseInt(args[0],10); //parses concurrency argument
   if(Number.isNaN(concurrency)){ concurrency = 5; } //defaults when no valid number provided
   concurrency = Math.max(1, concurrency); //ensures at least one concurrent request as zero or negative provide no downloads
+  if(concurrency > MAX_CONCURRENCY){ console.log(`run concurrency exceeds ${MAX_CONCURRENCY}`); concurrency = MAX_CONCURRENCY; } //warns and caps at limit
   console.log(`run concurrency set to ${concurrency}`); //logs enforced concurrency value
   const results = {}; //object to store averages for this run
   for(const url of urls){ //loops through urls


### PR DESCRIPTION
## Summary
- cap concurrency to 50 and warn when exceeded
- document max concurrency in performance guide

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68438e6409748322bccf7b3db4eb3ae2