### PR TITLE
Add retry logic for purge and performance requests

### DIFF
--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -1,4 +1,4 @@
-const axios = require('axios'); //imports axios for HTTP requests
+const fetchRetry = require('./request-retry'); //imports fetch with retry
 const {performance} = require('perf_hooks'); //imports performance for timing
 const qerrors = require('qerrors'); //imports qerrors for error logging
 const fs = require('fs'); //imports fs for writing json results
@@ -17,7 +17,7 @@ async function getTime(url){ //measures single download time
   if(process.env.CODEX === `True`){ //checks if running in Codex
    await wait(100); //mocks network delay
   } else {
-   await axios.get(url, {responseType: `arraybuffer`}); //makes real request
+   await fetchRetry(url,{responseType:`arraybuffer`}); //makes request with retry
   }
   const time = performance.now() - start; //calculates elapsed
   console.log(`getTime is returning ${time}`); //logs return

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -1,4 +1,4 @@
-const axios = require('axios'); //imports axios for HTTP requests
+const fetchRetry = require('./request-retry'); //imports fetch with retry
 const fs = require('fs').promises; //imports fs for reading hash file using promises
 const qerrors = require('qerrors'); //imports qerrors for error logging
 
@@ -10,7 +10,7 @@ async function purgeCdn(file){ //calls jsDelivr purge endpoint
    console.log(`purgeCdn is returning 200`); //logs mocked result
    return 200; //returns mock status code
   }
-  const res = await axios.get(url); //sends purge request
+  const res = await fetchRetry(url); //sends purge request with retry
   console.log(`purgeCdn is returning ${res.status}`); //logs response status
   return res.status; //returns status code
  } catch(err){

--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -1,0 +1,27 @@
+const axios = require('axios'); //imports axios for HTTP requests
+const qerrors = require('qerrors'); //imports qerrors for error logging
+
+function wait(ms){ //pauses execution for ms milliseconds
+ console.log(`wait is running with ${ms}`); //logs wait start
+ return new Promise(res=>setTimeout(()=>{console.log(`wait is returning undefined`);res();},ms)); //resolves after delay
+}
+
+async function fetchRetry(url,opts={},attempts=3){ //performs axios.get with retries
+ console.log(`fetchRetry is running with ${url},${attempts}`); //logs function start
+ for(let i=1;i<=attempts;i++){ //loops over retry attempts
+  try{
+   const res=await axios.get(url,opts); //sends request to url
+   console.log(`fetchRetry is returning ${res.status}`); //logs success status
+   return res; //returns axios response
+  }catch(err){
+   qerrors(err,`fetch attempt ${i}`,{url,attempt:i}); //logs failed attempt
+   if(i===attempts){ //checks if final attempt reached
+    throw err; //rethrows error after final failure
+   }
+   const delay=2**(i-1)*100; //calculates exponential backoff delay
+   await wait(delay); //waits before next attempt
+  }
+ }
+}
+
+module.exports=fetchRetry; //exports fetchRetry utility


### PR DESCRIPTION
## Summary
- add `request-retry` utility for axios calls with exponential backoff
- use the new retry helper in `purge-cdn.js`
- use the new retry helper in `performance.js`

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: cannot find module 'qerrors')*

------
https://chatgpt.com/codex/tasks/task_b_6843b878012883228acbcc4bcd69a328