### PR TITLE
Add artifact retention settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1 # package files for deployment
         with:
           path: dist #upload only production files
+          retention-days: 30 # keep artifact for 30 days
   tag: # job to create release tags #adds tagging job
     needs: build # wait for build job #ensures build completed
     runs-on: ubuntu-latest # use same runner #uses ubuntu

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -26,9 +26,11 @@ jobs:
         with:
           name: cdn-performance # artifact name
           path: performance.log # artifact path
+          retention-days: 30 # keep artifact for 30 days
       - name: Upload json
         uses: actions/upload-artifact@v3 # archive json
         with:
           name: cdn-performance-json # artifact name for json
           path: performance-results.json # artifact path for json
+          retention-days: 30 # keep artifact for 30 days
 


### PR DESCRIPTION
## Summary
- retain weekly performance logs for 30 days
- keep deployment artifact for 30 days

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843b87e8eac8322baa059fd15fb12bb