### PR TITLE
Update caching headers

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -6,7 +6,7 @@ location ~* \.(?:css|png|jpe?g|svg|gif)$ { # serves css and image files with cac
     brotli on; # enables brotli compression
     brotli_static on; # serves .br files if present
     brotli_types text/css image/svg+xml image/png image/jpeg image/gif; # types compressed with brotli
-    add_header Cache-Control "public, max-age=31536000"; # caches assets for a year
+    add_header Cache-Control "public, max-age=31536000, immutable"; # caches assets for a year without revalidation
     etag on; # enables ETag header for better cache validation
     add_header Last-Modified $date_gmt; # sets Last-Modified header for caching
 }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -10,14 +10,14 @@ location ~* \.(?:css|png|jpe?g|svg|gif)$ {
     brotli on;
     brotli_static on;
     brotli_types text/css image/svg+xml image/png image/jpeg image/gif;
-    add_header Cache-Control "public, max-age=31536000";
+    add_header Cache-Control "public, max-age=31536000, immutable";
     etag on;
     add_header Last-Modified $date_gmt;
 }
 ```
 
-These directives ensure assets are compressed when possible and cached by browsers for up to one year. The `ETag` and `Last-Modified` headers allow conditional requests so clients avoid re-downloading unchanged files.
+These directives ensure assets are compressed when possible and cached by browsers for up to one year without revalidation thanks to the `immutable` directive. The `ETag` and `Last-Modified` headers allow conditional requests so clients avoid re-downloading unchanged files.
 
 ## Hashed file names
 
-The build script renames `core.min.css` to a file containing an eight character SHA‑1 hash (for example `core.77526ae8.min.css`). This unique filename lets you serve the file with `Cache-Control: public, max-age=31536000` because updates produce a completely new filename. Older hashed files are removed on each build so only the latest hash is present. When a new build is deployed you must purge any CDN caches so the new hashed file is available; otherwise clients may continue receiving the old file for up to a year.
+The build script renames `core.min.css` to a file containing an eight character SHA‑1 hash (for example `core.77526ae8.min.css`). This unique filename lets you serve the file with `Cache-Control: public, max-age=31536000, immutable` because updates produce a completely new filename. Older hashed files are removed on each build so only the latest hash is present. When a new build is deployed you must purge any CDN caches so the new hashed file is available; otherwise clients may continue receiving the old file for up to a year.


### PR DESCRIPTION
## Summary
- update Cache-Control header in deployment/nginx.conf
- document immutability in docs/self-hosting.md

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843b8850c7c83229a1269737de40a6e