### PR TITLE
Update CDN purge path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
           const fs=require('fs'); //imports file system
           const purge=require('./scripts/purge-cdn'); //imports purge function
           const hash=fs.readFileSync('build.hash','utf8').trim(); //reads hash
-          purge(`dist/core.${hash}.min.css`).then(c=>{ //calls purge on new path
+          purge(`core.${hash}.min.css`).then(c=>{ //calls purge on new file
            console.log(`purge result ${c}`); //logs purge response code
           }).catch(e=>{console.error(e);process.exit(1);}); //handles errors
           EOF


### PR DESCRIPTION
## Summary
- purge jsDelivr CDN with `core.${hash}.min.css` instead of dist path

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: missing qerrors module)*

------
https://chatgpt.com/codex/tasks/task_b_6843c8fbb4348322b09904b8d95a6fdb