### PR TITLE
Add cache to performance workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -15,6 +15,13 @@ jobs:
         uses: actions/setup-node@v3 # install node
         with:
           node-version: 18 # desired node version
+      - name: Cache node modules #speeds install
+        uses: actions/cache@v3 #restore node_modules
+        with:
+          path: node_modules #directory to cache
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }} #unique cache key
+          restore-keys: |
+            ${{ runner.os }}-node- #fallback key prefix
       - name: Install dependencies
         run: npm ci # uses lock file for deterministic install
       - name: Build CSS # generates hashed CSS before performance test


### PR DESCRIPTION
## Summary
- cache `node_modules` in the performance workflow like deploy workflow

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/p-limit)*
- `npm run lint` *(fails: stylelint not found)*
- `npm run build` *(fails: Cannot find module 'qerrors')*

------
https://chatgpt.com/codex/tasks/task_b_6843c9110ee083228f211e841f638003