### PR TITLE
Add static-web-server configuration

### DIFF
--- a/.config/static-web-server.toml
+++ b/.config/static-web-server.toml
@@ -1,0 +1,12 @@
+compression = true # enables dynamic gzip/brotli compression
+compression-static = true # serves precompressed .gz or .br files when available
+compression-gzip-extensions = ["css", "png", "jpg", "jpeg", "svg", "gif"] # gzip only these types
+compression-brotli-extensions = ["css", "png", "jpg", "jpeg", "svg", "gif"] # brotli only these types
+http-etag = true # enables ETag header
+http-last-modified = true # enables Last-Modified header
+cache-control-max-age = 31536000 # 1 year max age caching
+cache-control-immutable = true # immutable caching so no revalidation
+
+[[headers]]
+source = "**/*.{css,png,jpg,jpeg,svg,gif}" # pattern to match assets
+headers = { "Cache-Control" = "public, max-age=31536000, immutable" } # replicates nginx caching header


### PR DESCRIPTION
## Summary
- add `.config/static-web-server.toml` enabling gzip/brotli and year-long cache

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `static-web-server -w ./.config/static-web-server.toml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843c92c612c83229a9711589b5d875a