### PR TITLE
Fix purge-cdn import in integration test

### DIFF
--- a/test/integration-purge.test.js
+++ b/test/integration-purge.test.js
@@ -18,7 +18,7 @@ before(() => {
   delete require.cache[require.resolve('../scripts/purge-cdn')]; //ensure fresh purge module
   build = require('../scripts/build'); //import build function
   updateHtml = require('../scripts/updateHtml'); //import updateHtml function
-  purgeCdn = require('../scripts/purge-cdn'); //import purgeCdn function
+  ({purgeCdn} = require('../scripts/purge-cdn')); //import purgeCdn function via destructuring
 });
 
 after(() => {


### PR DESCRIPTION
## Summary
- use destructuring to load `purgeCdn` function in integration test

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6844a7a32b1883229435193fabefb336