### PR TITLE
Add test prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,8 @@ clients fetch the new hash.
 ## License
 This project is licensed under the [MIT License](LICENSE).
 
+## Testing
+Run `npm install` before executing `npm test` so required modules like jsdom are available.
+
 ## Performance testing
 A script for measuring download times from jsDelivr and GitHub Pages is in [docs/performance.md](docs/performance.md). Use it to verify asset delivery speed under load. Pass `--json` to append results to `performance-results.json` for automation.


### PR DESCRIPTION
## Summary
- document that tests require `npm install` to pull dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6844a7a401e08322944aed3d7ac0939e