### PR TITLE
Fix comment style in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Exclude build artifacts and performance results
 core.min.css
 core.*.min.css
-core.*.min.css.gz //(ignore gzip build files)
-core.*.min.css.br //(ignore brotli build files)
+core.*.min.css.gz #(ignore gzip build files)
+core.*.min.css.br #(ignore brotli build files)
 build.hash
 performance-results.json


### PR DESCRIPTION
## Summary
- update `.gitignore` comment style so Git parses them correctly

## Testing
- `npm run test` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6844b372ea608322ae340b51ae351e34