### PR TITLE
Add module imports for purge script

### DIFF
--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -24,7 +24,8 @@
  */
 
 const qerrors = require('qerrors'); // Centralized error logging with contextual information
-// fetchRetry and fs are expected to be provided by the runtime environment
+const fs = require('fs').promises; // Node promise-based filesystem for async use
+const fetchRetry = require('./request-retry'); // Retry wrapper for HTTP requests
 
 /*
  * CDN CACHE PURGE FUNCTION

--- a/test/purge-cdn.test.js
+++ b/test/purge-cdn.test.js
@@ -3,26 +3,32 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const Module = require('module'); // access module loader for dependency stubs
 const {describe, it, beforeEach, afterEach} = require('node:test');
 
-let purgeCdn, run;
-let tmpDir, calledUrl;
+let purgeCdn, run; // will hold imported functions under test
+let tmpDir, calledUrl; // track temporary dir and requested URL for assertions
 
-// helper to load module with globals
-function load(){
+// helper to load module with dependency stubs
+const baseReq = Module.prototype.require; // original require used by helper.js
+function load(stubs={}){
+  Module.prototype.require = function(id){
+    if(id === './request-retry') return stubs.fetchRetry; // provides fetch stub
+    if(id === 'fs') return { ...baseReq.call(this,'fs'), promises: stubs.fs || baseReq.call(this,'fs').promises }; // overrides fs if given
+    return baseReq.call(this,id); // fallback to existing behavior
+  };
   delete require.cache[require.resolve('../scripts/purge-cdn')];
   ({purgeCdn, run} = require('../scripts/purge-cdn'));
+  Module.prototype.require = baseReq; // restore require after loading
 }
 
 describe('purgeCdn offline', {concurrency:false}, () => {
   beforeEach(() => {
     process.env.CODEX = 'True';
-    global.fetchRetry = async () => ({status:999}); // fetch stub when offline
-    load();
+    load({fetchRetry: async () => ({status:999})}); // load script with offline fetch stub
   });
   afterEach(() => {
     delete process.env.CODEX;
-    delete global.fetchRetry;
   });
   it('returns 200 when CODEX True', async () => {
     const code = await purgeCdn('file.css');
@@ -33,11 +39,9 @@ describe('purgeCdn offline', {concurrency:false}, () => {
 describe('purgeCdn online', {concurrency:false}, () => {
   beforeEach(() => {
     calledUrl = '';
-    global.fetchRetry = async (url) => { calledUrl = url; return {status:201}; };
-    load();
+    load({fetchRetry: async (url) => { calledUrl = url; return {status:201}; }}); // script uses stubbed fetch
   });
   afterEach(() => {
-    delete global.fetchRetry;
   });
   it('returns status from fetchRetry', async () => {
     const code = await purgeCdn('abc.css');
@@ -52,15 +56,11 @@ describe('run uses hash', {concurrency:false}, () => {
     fs.writeFileSync(path.join(tmpDir, 'build.hash'), '12345678');
     process.chdir(tmpDir);
     calledUrl = '';
-    global.fetchRetry = async (url) => { calledUrl = url; return {status:202}; };
-    global.fs = fs.promises;
-    load();
+    load({fetchRetry: async (url) => { calledUrl = url; return {status:202}; }, fs: fs.promises}); // stub dependencies with temp dir fs
   });
   afterEach(() => {
     process.chdir(path.resolve(__dirname, '..'));
     fs.rmSync(tmpDir, {recursive:true, force:true});
-    delete global.fetchRetry;
-    delete global.fs;
   });
   it('purges hashed file', async () => {
     const code = await run();


### PR DESCRIPTION
## Summary
- import `fs.promises` and `fetchRetry` inside `purge-cdn.js`
- mock dependencies in tests using module loader patches

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6844b37a9e308322b62483df24e95c54