### PR TITLE
Insert CDN placeholder in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" type="text/css" href="qore.css">
     <link rel="stylesheet" type="text/css" href="variables.css">
+    <link rel="stylesheet" href="core.aaaaaaaa.min.css"> <!-- added hashed stylesheet link for CDN builds -->
+    {{CDN_BASE_URL}} <!-- placeholder for CDN base URL -->
 </head>
 <body>
     <!-- Modern Header with Navigation -->


### PR DESCRIPTION
## Summary
- add example hashed CSS link in `index.html`
- include `{{CDN_BASE_URL}}` placeholder after the link

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6844b382b58083228903a7488423e1cf