### PR TITLE
Update test cleanup for CODEX env

### DIFF
--- a/test/integration-purge.test.js
+++ b/test/integration-purge.test.js
@@ -24,6 +24,7 @@ before(() => {
 after(() => {
   process.chdir(path.resolve(__dirname, '..')); //return to repo root
   fs.rmSync(tmpDir, {recursive: true, force: true}); //remove temp directory
+  delete process.env.CODEX; //restore CODEX env so other tests run online
 });
 
 describe('build update purge', {concurrency:false}, () => { //group test steps


### PR DESCRIPTION
## Summary
- restore `CODEX` environment variable in integration purge test

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6845100e404083229b1991095a13b134