### PR TITLE
Fix browser CSS path handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ if (typeof window === 'undefined') {
  const link = document.createElement('link'); // Creates <link> element for stylesheet injection
  link.rel = 'stylesheet'; // Specifies relationship type to browser
   link.type = 'text/css'; // Explicit MIME type for clarity across tools
-  const cssPath = typeof require === 'function' && require.resolve ? require.resolve('./qore.css') : document.currentScript.src.replace('index.js', 'qore.css'); // derives path via require.resolve when available, otherwise from script src
+  const cssPath = document.currentScript && document.currentScript.src ? document.currentScript.src.replace('index.js', 'qore.css') : require.resolve('./qore.css'); // uses current script src when possible then falls back to require.resolve
   link.href = cssPath; // assigns resolved CSS path to href for consistent loading
   document.head.appendChild(link); // Inserts stylesheet into DOM for immediate effect
 }


### PR DESCRIPTION
## Summary
- adjust browser path logic for CSS to check `document.currentScript` first

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_68451021b3c083229eb3c4a1d81e356d