### PR TITLE
Fix hashed css link update

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Qore CSS Modern Demo</title>
     <link rel="stylesheet" href="variables.css">
-    <link rel="stylesheet" href="qore.css">
+    <link rel="stylesheet" href="core.aaaaaaaa.min.css"> //(placeholder for build hash replacement)
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/iconscout/unicons@release/css/line.css">
 </head>
 <body>

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -72,7 +72,12 @@ async function updateHtml(){
    * Global flag (g) ensures all references in the file are updated in one pass.
    * This handles cases where CSS is referenced multiple times (preload, link, etc.).
    */
-  let updated = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); // Substitutes hashed CSS filename
+  let updated; //(declare variable for updated html)
+  if(/core\.[a-f0-9]{8}\.min\.css/.test(html)){ //(detect existing hashed reference)
+   updated = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); //(update existing hash)
+  } else {
+   updated = html.replace(/qore\.css/g, `core.${hash}.min.css`); //(replace qore.css when no hashed filename)
+  }
   
   /*
    * CDN PLACEHOLDER SUBSTITUTION

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -29,4 +29,12 @@ describe('updateHtml', () => {
     assert.ok(updated.includes('http://testcdn'));
     assert.strictEqual(hash, '12345678');
   });
+
+  it('replaces qore.css when hash missing', async () => { //(new scenario for plain css)
+    fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="qore.css">'); //(setup html without placeholder)
+    const hash = await updateHtml(); //(run update on qore.css html)
+    const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); //(read modified html)
+    assert.ok(updated.includes('core.12345678.min.css')); //(verify replacement)
+    assert.strictEqual(hash, '12345678'); //(ensure returned hash unchanged)
+  });
 });


### PR DESCRIPTION
## Summary
- update HTML to use placeholder hashed filename
- swap qore.css for hashed filename during update
- add test for qore.css replacement

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_68457568f6e083228a11c793e0b8ada6