### PR TITLE
Improve request retry axios usage

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -23,7 +23,10 @@
  */
 
 const axios = require('axios'); // Robust HTTP client library with comprehensive feature set
+const http = require('node:http'); // Node HTTP used for keep-alive agent
+const https = require('node:https'); // Node HTTPS used for keep-alive agent
 const qerrors = require('qerrors'); // Centralized error logging with contextual information preservation
+const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true}),httpsAgent:new https.Agent({keepAlive:true})}); // axios instance reusing persistent agents
 
 /*
  * DELAY UTILITY FUNCTION
@@ -77,11 +80,11 @@ async function fetchRetry(url,opts={},attempts=3){
    try{
     /*
      * HTTP REQUEST EXECUTION
-     * Rationale: axios.get provides reliable HTTP client with good error handling,
+     * Rationale: axiosInstance.get provides reliable HTTP client with good error handling,
      * timeout support, and comprehensive response object. Options object allows
      * caller to specify responseType, headers, and other request configuration.
      */
-    const res=await axios.get(url,opts); 
+    const res=await axiosInstance.get(url,opts); // uses persistent axios instance for all retries
    console.log(`fetchRetry is returning ${res.status}`); // Logs successful response status
    return res; // Returns complete axios response object for caller processing
   }catch(err){

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,7 +1,7 @@
 const Module = require('module');
 const path = require('node:path');
 const orig = Module.prototype.require;
-const axiosStub = {get: async ()=>({status:200})}; // reusable axios stub
+const axiosStub = {get: async ()=>({status:200}),create(){return this;}}; // reusable axios stub with create method
 const qerrorsStub = () => {}; // reusable qerrors stub
 Module.prototype.require = function(id){
   if(id==='axios') return axiosStub; // returns same axios stub each require


### PR DESCRIPTION
## Summary
- share axios instance with keep-alive agents
- adjust axios stub with `create` method for tests

## Testing
- `npm test` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_68457583d7b083229c1060b7a6bd9f04