### PR TITLE
Limit axios agent sockets

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -26,7 +26,7 @@ const axios = require('axios'); // Robust HTTP client library with comprehensive
 const http = require('node:http'); // Node HTTP used for keep-alive agent
 const https = require('node:https'); // Node HTTPS used for keep-alive agent
 const qerrors = require('qerrors'); // Centralized error logging with contextual information preservation
-const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true}),httpsAgent:new https.Agent({keepAlive:true})}); // axios instance reusing persistent agents
+const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:50}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:50})}); // axios instance reusing persistent agents with connection limit
 
 /*
  * DELAY UTILITY FUNCTION


### PR DESCRIPTION
## Summary
- cap concurrent sockets for request retries by setting `maxSockets`

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_684580d9aaf08322a8f1d0f9c8f03aaf