### PR TITLE
Disable dynamic compression

### DIFF
--- a/.config/static-web-server.toml
+++ b/.config/static-web-server.toml
@@ -2,7 +2,7 @@
 host = "0.0.0.0"
 port = 80
 root = "."
-compression = true # enables dynamic gzip/brotli compression
+compression = false # disables dynamic gzip/brotli compression as files are precompressed
 compression-static = true # serves precompressed .gz or .br files when available
 compression-gzip-extensions = ["css", "png", "jpg", "jpeg", "svg", "gif"] # gzip only these types
 compression-brotli-extensions = ["css", "png", "jpg", "jpeg", "svg", "gif"] # brotli only these types

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,9 +1,9 @@
 # Nginx snippet to cache and compress qoreCSS assets
 location ~* \.(?:css|png|jpe?g|svg|gif)$ { # serves css and image files with caching
-    gzip on; # enables gzip compression
+    # gzip on removed to use precompressed files only # dynamic gzip disabled
     gzip_static on; # serves .gz files if present
     gzip_types text/css image/svg+xml image/png image/jpeg image/gif; # types compressed with gzip
-    brotli on; # enables brotli compression
+    # brotli on removed to use precompressed files only # dynamic brotli disabled
     brotli_static on; # serves .br files if present
     brotli_types text/css image/svg+xml image/png image/jpeg image/gif; # types compressed with brotli
     add_header Cache-Control "public, max-age=31536000, immutable"; # caches assets for a year without revalidation


### PR DESCRIPTION
## Summary
- disable dynamic gzip & brotli compression in the static web server config
- remove nginx `gzip on` and `brotli on` lines

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_b_684580dc2c3c83228bab19b3946f351d