### PR TITLE
Make queue limit configurable

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,19 +8,19 @@ This document explains how to measure download times for `core.min.css` when ser
    ```bash
    npm install axios qerrors
    ```
-2. Execute the script specifying how many download attempts to run (defaults to `5`). Only `5` requests are made at the same time:
+2. Execute the script specifying how many download attempts to run (defaults to `5`). The queue size can be overridden with the `QUEUE_LIMIT` environment variable and defaults to `5`:
    ```bash
    node scripts/performance.js 10 --json
    ```
    The optional `--json` flag appends a timestamped entry to `performance-results.json` for automation. The script fetches `core.<hash>.min.css` when `build.hash` exists, otherwise it falls back to `core.min.css`. When `CODEX=True` it mocks network calls for offline testing.
 
-The output shows the average download time in milliseconds for each provider. Increase the value up to `50` to run more attempts while still queuing them `5` at a time. Values above `50` will trigger a warning and be capped at `50`.
+The output shows the average download time in milliseconds for each provider. Increase the value up to `50` to run more attempts while still queuing them according to `QUEUE_LIMIT` (default `5`). Values above `50` will trigger a warning and be capped at `50`.
 
 ## Manual checklist
 
 If you prefer testing manually or need to verify results with tools of your choice, use the following steps:
 
-1. Choose a reasonable run count, such as 10 download attempts, keeping in mind the script will cap values at `50` and queue requests in groups of `5`.
+1. Choose a reasonable run count, such as 10 download attempts, keeping in mind the script will cap values at `50` and queue requests in groups defined by `QUEUE_LIMIT` (default `5`).
 2. Measure download times with your preferred tool (`curl`, `ab`, `wrk`, etc.) against the file specified in `build.hash` when present:
    - `https://cdn.jsdelivr.net/gh/Bijikyu/qoreCSS/core.<hash>.min.css`
    - `https://bijikyu.github.io/qoreCSS/core.<hash>.min.css`

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -28,7 +28,8 @@ const fs = require('fs'); // File system operations for reading/writing test res
 const pLimit = require('p-limit'); // Concurrency limiting to prevent overwhelming target servers
 const CDN_BASE_URL = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; // Environment-configurable CDN endpoint
 const MAX_CONCURRENCY = 50; // Upper safety limit to prevent excessive server load
-const QUEUE_LIMIT = 5; // Conservative concurrent request limit for respectful testing
+const envLimit = parseInt(process.env.QUEUE_LIMIT,10); // reads queue size from environment variable
+const QUEUE_LIMIT = Number.isNaN(envLimit) ? 5 : envLimit; // defaults to 5 when env variable missing
 const HISTORY_MAX = 50; // maximum entries kept in performance history file
 
 /*


### PR DESCRIPTION
## Summary
- allow queue size override through `QUEUE_LIMIT` env variable
- document how to control queue size in performance testing

## Testing
- `npm test` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_684580de4c748322a894bd3e9ba7efdd