### PR TITLE
Allow socket limit override for HTTP agents

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,7 +8,7 @@ This document explains how to measure download times for `core.min.css` when ser
    ```bash
    npm install axios qerrors
    ```
-2. Execute the script specifying how many download attempts to run (defaults to `5`). The queue size can be overridden with the `QUEUE_LIMIT` environment variable and defaults to `5`:
+2. Execute the script specifying how many download attempts to run (defaults to `5`). The queue size can be overridden with the `QUEUE_LIMIT` environment variable and defaults to `5`. The HTTP agents respect `SOCKET_LIMIT` when set to adjust their connection pool (default `50`):
    ```bash
    node scripts/performance.js 10 --json
    ```

--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -26,7 +26,9 @@ const axios = require('axios'); // Robust HTTP client library with comprehensive
 const http = require('node:http'); // Node HTTP used for keep-alive agent
 const https = require('node:https'); // Node HTTPS used for keep-alive agent
 const qerrors = require('qerrors'); // Centralized error logging with contextual information preservation
-const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:50}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:50})}); // axios instance reusing persistent agents with connection limit
+const envSockets = parseInt(process.env.SOCKET_LIMIT,10); // reads connection limit from env var
+const socketLimit = Number.isNaN(envSockets) ? 50 : envSockets; // defaults to 50 when env var missing
+const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:socketLimit}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:socketLimit})}); // axios instance using variable connection limit
 
 /*
  * DELAY UTILITY FUNCTION


### PR DESCRIPTION
## Summary
- allow configuring maxSockets using `SOCKET_LIMIT`
- mention this environment variable in the performance docs

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_6846889705bc8322a007379a93d37078