### PR TITLE
Update nginx Last-Modified directive

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -8,5 +8,5 @@ location ~* \.(?:css|png|jpe?g|svg|gif)$ { # serves css and image files with cac
     brotli_types text/css image/svg+xml image/png image/jpeg image/gif; # types compressed with brotli
     add_header Cache-Control "public, max-age=31536000, immutable"; # caches assets for a year without revalidation
     etag on; # enables ETag header for better cache validation
-    add_header Last-Modified $date_gmt; # sets Last-Modified header for caching
+    last_modified on; # sets Last-Modified using file mtime for caching
 }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -12,7 +12,7 @@ location ~* \.(?:css|png|jpe?g|svg|gif)$ {
     brotli_types text/css image/svg+xml image/png image/jpeg image/gif;
     add_header Cache-Control "public, max-age=31536000, immutable";
     etag on;
-    add_header Last-Modified $date_gmt;
+    last_modified on;
 }
 ```
 
@@ -25,7 +25,7 @@ location ~* \.html$ {
 ```
 <!-- //short cache header snippet for html pages -->
 
-These directives ensure assets are compressed when possible and cached by browsers for up to one year without revalidation thanks to the `immutable` directive. The `ETag` and `Last-Modified` headers allow conditional requests so clients avoid re-downloading unchanged files.
+These directives ensure assets are compressed when possible and cached by browsers for up to one year without revalidation thanks to the `immutable` directive. The `ETag` and `Last-Modified` headers allow conditional requests so clients avoid re-downloading unchanged files. Using `last_modified on;` tells Nginx to emit the actual file modification time so browsers can send `If-Modified-Since` and receive `304 Not Modified` when appropriate.
 
 ## Hashed file names
 


### PR DESCRIPTION
## Summary
- use `last_modified on;` in nginx snippet so browsers get file modification times
- document new nginx directive and why it matters for 304 responses

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*
- `nginx -t -c $(pwd)/deployment/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68468fbb357883228a554471d294dfd3