### PR TITLE
Enable parallel tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,10 @@ jobs:
             ${{ runner.os }}-node- # fallback key prefix
       - name: Install dependencies
         run: npm ci # uses lock file for deterministic install
-      - name: Run tests #executes suite before build
-        run: npm test #runs npm test command
+      - name: Run tests #executes suite with Node parallelism
+        run: node --test
+      - name: Show threads used
+        run: node -e "console.log('threads', require('os').cpus().length)"
       - name: Lint CSS
         run: npm run lint # ensure styles follow rules before build
       - name: Build CSS

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,8 +24,10 @@ jobs:
             ${{ runner.os }}-node- #fallback key prefix
       - name: Install dependencies
         run: npm ci # uses lock file for deterministic install
-      - name: Run tests #executes suite before build
-        run: npm test #runs npm test command
+      - name: Run tests #executes suite with Node parallelism
+        run: node --test
+      - name: Show threads used
+        run: node -e "console.log('threads', require('os').cpus().length)"
       - name: Build CSS # generates hashed CSS before performance test
         run: npm run build # ensures build.hash and hashed CSS exist
       - name: Run performance script

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "lint": "stylelint qore.css variables.css",
-    "test": "node --test --test-concurrency=1"
+    "test": "node --test"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -25,6 +25,7 @@ const fetchRetry = require('./request-retry'); // HTTP client with retry logic f
 const {performance} = require('perf_hooks'); // High-resolution timing API for accurate measurements
 const qerrors = require('qerrors'); // Centralized error logging with contextual information
 const fs = require('fs'); // File system operations for reading/writing test results
+const path = require('node:path'); // path utilities for directory operations
 const pLimit = require('p-limit'); // Concurrency limiting to prevent overwhelming target servers
 const CDN_BASE_URL = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; // Environment-configurable CDN endpoint
 const maxEnv = parseInt(process.env.MAX_CONCURRENCY,10); // reads max concurrency from environment
@@ -155,8 +156,8 @@ async function measureUrl(url, count){
  * This provides comprehensive CDN performance evaluation with flexible
  * configuration and optional data persistence.
  */
-async function run(){ 
- console.log(`run is running with ${process.argv.length}`); // Logs execution start for monitoring
+async function run(dir='.'){
+ console.log(`run is running with ${dir}`); // logs directory parameter for monitoring
  try {
   /*
    * BUILD HASH INTEGRATION
@@ -165,8 +166,9 @@ async function run(){
    * that users will actually receive. Fallback to core.min.css handles
    * cases where build hasn't run yet.
    */
-  let hash = ``; 
-  if(fs.existsSync(`build.hash`)){ hash = fs.readFileSync(`build.hash`,`utf8`).trim(); } 
+  let hash = ``;
+  const hashPath = path.join(dir,'build.hash'); //(path to build hash file)
+  if(fs.existsSync(hashPath)){ hash = fs.readFileSync(hashPath,'utf8').trim(); }
   const fileName = hash ? `core.${hash}.min.css` : `core.min.css`; 
   
   /*
@@ -227,7 +229,7 @@ async function run(){
    * Timestamped entries allow correlation with deployments and incidents.
    */
   if(jsonFlag){
-   const file = `performance-results.json`;
+   const file = path.join(dir,'performance-results.json'); //(results history file path)
    const history = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : []; // Loads existing history or creates new array
    const entry = {timestamp: new Date().toISOString(), results}; // Creates timestamped entry
    history.push(entry); // Appends to historical data

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -25,6 +25,7 @@
 
 const qerrors = require('qerrors'); // Centralized error logging with contextual information
 const fs = require('fs').promises; // Node promise-based filesystem for async use
+const path = require('node:path'); // path utilities for directory operations
 const fetchRetry = require('./request-retry'); // Retry wrapper for HTTP requests
 
 /*
@@ -89,17 +90,17 @@ async function purgeCdn(file){
  * This ensures purge operations target the exact file that was just built,
  * maintaining consistency between build and deployment processes.
  */
-async function run(){
- console.log(`run is running with ${process.argv.length}`); // Logs execution start for monitoring
+async function run(dir='.'){
+ console.log(`run is running with ${dir}`); // logs directory parameter for monitoring
  try {
-  await fs.access(`build.hash`); // ensures build hash file exists before reading
+  await fs.access(path.join(dir,'build.hash')); // ensures build hash file exists before reading
   /*
    * BUILD HASH INTEGRATION
    * Rationale: Reads hash from build system to ensure purge targets the
    * correct file version. This maintains tight coupling between build
    * and purge operations, preventing purging of wrong file versions.
    */
-  const hash = (await fs.readFile(`build.hash`, `utf8`)).trim(); // Reads current build hash from filesystem
+  const hash = (await fs.readFile(path.join(dir,'build.hash'), `utf8`)).trim(); // Reads current build hash from filesystem
   
   /*
    * FILENAME CONSTRUCTION

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -22,6 +22,7 @@
 
 const fs = require('fs').promises; // File system operations using promises for consistent async patterns
 const qerrors = require('qerrors'); // Centralized error logging with contextual information
+const path = require('node:path'); // path utilities for directory operations
 
 /*
  * HTML UPDATE FUNCTION
@@ -37,8 +38,8 @@ const qerrors = require('qerrors'); // Centralized error logging with contextual
  * Comprehensive try/catch with detailed logging enables debugging of file system
  * issues, missing dependencies, or regex replacement failures.
  */
-async function updateHtml(){ 
- console.log(`updateHtml is running with ${process.argv.length}`); // Logs function entry for debugging and monitoring
+async function updateHtml(dir='.'){
+ console.log(`updateHtml is running with ${dir}`); //logs directory parameter for debugging
  try {
 
   /*
@@ -48,7 +49,7 @@ async function updateHtml(){
    * and HTML updates to happen later in the deployment pipeline.
    * trim() removes any whitespace that might interfere with filename generation.
    */
-  const hash = (await fs.readFile('build.hash','utf8')).trim(); // Reads current build hash for filename replacement
+  const hash = (await fs.readFile(path.join(dir,'build.hash'),'utf8')).trim(); // Reads current build hash for filename replacement
   
   /*
    * HTML CONTENT LOADING
@@ -56,7 +57,7 @@ async function updateHtml(){
    * which are typically small. This enables string manipulation operations
    * that would be complex with streaming approaches.
    */
-  const html = await fs.readFile('index.html','utf8'); // Loads HTML content into memory for editing
+  const html = await fs.readFile(path.join(dir,'index.html'),'utf8'); // Loads HTML content from directory
   
   /*
    * CDN URL CONFIGURATION
@@ -95,7 +96,7 @@ async function updateHtml(){
    * Rationale: Writing back to the same file updates references in place.
    * This maintains file permissions and any other metadata while updating content.
    */
-  await fs.writeFile('index.html', updated); // Persists updated HTML to disk
+  await fs.writeFile(path.join(dir,'index.html'), updated); // Persists updated HTML to disk in directory
 
   console.log(`updateHtml has run resulting in core.${hash}.min.css`); // Logs successful completion with resulting filename
   console.log(`updateHtml is returning ${hash}`); // Logs return value for debugging

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -11,19 +11,17 @@ beforeEach(() => {
   process.env.CODEX = 'True';
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'buildtest-'));
   fs.writeFileSync(path.join(tmpDir, 'qore.css'), 'body{}');
-  process.chdir(tmpDir);
   delete require.cache[require.resolve('../scripts/build')];
   build = require('../scripts/build');
 });
 
 afterEach(() => {
-  process.chdir(path.resolve(__dirname, '..'));
   fs.rmSync(tmpDir, {recursive: true, force: true});
 });
 
 describe('build offline', {concurrency:false}, () => {
   it('creates hashed css and hash file', async () => {
-    const hash = await build();
+    const hash = await build(tmpDir); //(run build in temp dir)
     const minPath = path.join(tmpDir, `core.${hash}.min.css`);
     const hashFile = path.join(tmpDir, 'build.hash');
     assert.ok(fs.existsSync(minPath));

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -11,7 +11,6 @@ beforeEach(() => {
   dom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`); //(creates DOM for browser simulation)
   global.window = dom.window; //(exposes window for module)
   global.document = dom.window.document; //(exposes document for module)
-  process.chdir(path.resolve(__dirname, '..')); //(ensures correct module paths)
   delete require.cache[require.resolve('../index.js')]; //(reloads module for clean state)
   mod = require('../index.js'); //(imports module after DOM setup)
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,6 @@ const {describe, it, beforeEach, afterEach} = require('node:test');
 
 let mod;
 beforeEach(() => {
-  process.chdir(path.resolve(__dirname, '..')); // ensures paths resolve correctly
   delete require.cache[require.resolve('../index.js')]; // resets module cache
   mod = require('../index.js'); // imports module
 });

--- a/test/integration-purge.test.js
+++ b/test/integration-purge.test.js
@@ -12,7 +12,6 @@ before(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'purge-')); //create unique temp directory
   fs.writeFileSync(path.join(tmpDir, 'qore.css'), 'body{}'); //create placeholder css
   fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="core.aaaaaaaa.min.css">\n{{CDN_BASE_URL}}'); //create placeholder html
-  process.chdir(tmpDir); //switch to temp dir
   delete require.cache[require.resolve('../scripts/build')]; //ensure fresh build module
   delete require.cache[require.resolve('../scripts/updateHtml')]; //ensure fresh updateHtml module
   delete require.cache[require.resolve('../scripts/purge-cdn')]; //ensure fresh purge module
@@ -22,16 +21,15 @@ before(() => {
 });
 
 after(() => {
-  process.chdir(path.resolve(__dirname, '..')); //return to repo root
   fs.rmSync(tmpDir, {recursive: true, force: true}); //remove temp directory
   delete process.env.CODEX; //restore CODEX env so other tests run online
 });
 
 describe('build update purge', {concurrency:false}, () => { //group test steps
   it('updates html and purges cdn', async () => { //single integration test
-    const hash = await build(); //run build to create hashed css
+    const hash = await build(tmpDir); //run build to create hashed css
     process.env.CDN_BASE_URL = 'http://cdn'; //set cdn url for html update
-    await updateHtml(); //update html file with hash and cdn
+    await updateHtml(tmpDir); //update html file with hash and cdn
     const code = await purgeCdn(`core.${hash}.min.css`); //purge cdn using file name
     const html = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); //read updated html
     assert.ok(html.includes(`core.${hash}.min.css`)); //verify hashed css reference

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -12,7 +12,6 @@ before(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'integ-'));
   fs.writeFileSync(path.join(tmpDir, 'qore.css'), 'body{}');
   fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="core.aaaaaaaa.min.css">\n{{CDN_BASE_URL}}'); // placeholder with 8 digits
-  process.chdir(tmpDir);
   delete require.cache[require.resolve('../scripts/build')];
   delete require.cache[require.resolve('../scripts/updateHtml')];
   build = require('../scripts/build');
@@ -20,15 +19,14 @@ before(() => {
 });
 
 after(() => {
-  process.chdir(path.resolve(__dirname, '..'));
   fs.rmSync(tmpDir, {recursive: true, force: true});
 });
 
 describe('build and updateHtml', {concurrency:false}, () => {
   it('builds and updates html', async () => {
-    const hash = await build();
+    const hash = await build(tmpDir); //(run build in temp dir)
     process.env.CDN_BASE_URL = 'http://cdn';
-    await updateHtml();
+    await updateHtml(tmpDir); //(update html in temp dir)
     const html = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8');
     assert.ok(html.includes(`core.${hash}.min.css`));
     assert.ok(html.includes('http://cdn'));

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -39,7 +39,6 @@ describe('run trims history', {concurrency:false}, () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-')); //(temporary directory for file operations)
     const history = Array.from({length:55}, (_,i)=>({timestamp:`${i}`, results:{}})); //(pre-seeded history)
     fs.writeFileSync(path.join(tmpDir,'performance-results.json'), JSON.stringify(history)); //(create initial file)
-    process.chdir(tmpDir); //(switch cwd for script)
     process.argv = ['node','scripts/performance.js','1','--json']; //(setup argv for run function)
   });
   afterEach(() => {
@@ -47,7 +46,7 @@ describe('run trims history', {concurrency:false}, () => {
     process.argv = ['node','']; //(reset argv)
   });
   it('keeps last 50 entries', async () => {
-    await performance.run(); //(execute run to append and trim)
+    await performance.run(tmpDir); //(execute run to append and trim)
     const file = JSON.parse(fs.readFileSync(path.join(tmpDir,'performance-results.json'),'utf8')); //(read updated history)
     assert.strictEqual(file.length, 50); //(ensure trimming to max)
   });

--- a/test/purge-cdn.test.js
+++ b/test/purge-cdn.test.js
@@ -55,16 +55,14 @@ describe('run uses hash', {concurrency:false}, () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'purge-'));
     fs.writeFileSync(path.join(tmpDir, 'build.hash'), '12345678');
-    process.chdir(tmpDir);
     calledUrl = '';
     load({fetchRetry: async (url) => { calledUrl = url; return {status:202}; }, fs: fs.promises}); // stub dependencies with temp dir fs
   });
   afterEach(() => {
-    process.chdir(path.resolve(__dirname, '..'));
     fs.rmSync(tmpDir, {recursive:true, force:true});
   });
   it('purges hashed file', async () => {
-    const code = await run();
+    const code = await run(tmpDir); //(invoke run with directory)
     assert.strictEqual(code, 202);
     assert.ok(calledUrl.includes('core.12345678.min.css'));
   });

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -12,18 +12,16 @@ beforeEach(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'htmltest-'));
   fs.writeFileSync(path.join(tmpDir, 'build.hash'), '12345678');
   fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="core.aaaaaaaa.min.css">\n{{CDN_BASE_URL}}');
-  process.chdir(tmpDir);
 });
 
 afterEach(() => {
-  process.chdir(path.resolve(__dirname, '..'));
   fs.rmSync(tmpDir, {recursive: true, force: true});
 });
 
 describe('updateHtml', () => {
   it('updates html with hash and CDN url', async () => {
     process.env.CDN_BASE_URL = 'http://testcdn';
-    const hash = await updateHtml();
+    const hash = await updateHtml(tmpDir); //(update html in temp dir)
     const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8');
     assert.ok(updated.includes('core.12345678.min.css'));
     assert.ok(updated.includes('http://testcdn'));
@@ -32,7 +30,7 @@ describe('updateHtml', () => {
 
   it('replaces qore.css when hash missing', async () => { //(new scenario for plain css)
     fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="qore.css">'); //(setup html without placeholder)
-    const hash = await updateHtml(); //(run update on qore.css html)
+    const hash = await updateHtml(tmpDir); //(run update on qore.css html)
     const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); //(read modified html)
     assert.ok(updated.includes('core.12345678.min.css')); //(verify replacement)
     assert.strictEqual(hash, '12345678'); //(ensure returned hash unchanged)


### PR DESCRIPTION
## Summary
- remove concurrency limit from npm test
- update scripts to accept working directory arguments for concurrency safety
- adjust unit tests to operate without changing process cwd
- run tests directly in CI workflows and display CPU thread count

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_68468fc54dd883228f75350427319628