### PR TITLE
Import qerrors in build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,6 +29,7 @@ const crypto = require('crypto'); // Cryptographic functions for generating cont
 const {createGzip, createBrotliCompress} = require('zlib'); // Streaming compressors for optimized output
 const {pipeline} = require('stream/promises'); // Promise based pipeline for stream control
 const execFileAsync = promisify(execFile); // Promise-wrapped execFile for consistent async patterns
+const qerrors = require('qerrors'); // Centralized error logging with contextual information
 
 /*
  * MAIN BUILD FUNCTION


### PR DESCRIPTION
## Summary
- require `qerrors` in build script

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bc711f35883229e8db5ded69a1c35