### PR TITLE
Integrate axios‑retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "axios": "^1.6.0",
+    "axios-retry": "^3.6.0",
     "cssnano": "^5.1.15",
     "jsdom": "^22.1.0",
     "postcss": "^8.4.30",

--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -23,27 +23,13 @@
  */
 
 const axios = require('axios'); // Robust HTTP client library with comprehensive feature set
+const axiosRetry = require('axios-retry'); // Automated retry handling utility
 const http = require('node:http'); // Node HTTP used for keep-alive agent
 const https = require('node:https'); // Node HTTPS used for keep-alive agent
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information preservation
 const {parseEnvInt} = require('./utils/env-config'); // Centralized environment configuration utilities
 const socketLimit = parseEnvInt('SOCKET_LIMIT', 50, 1, 1000); // validates range 1-1000 with default 50
 const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:socketLimit}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:socketLimit})}); // axios instance using variable connection limit
-
-/*
- * DELAY UTILITY FUNCTION
- * 
- * Rationale: Implements non-blocking delays for exponential backoff strategy.
- * Promise-based approach integrates cleanly with async/await patterns.
- * Logging provides visibility into retry timing for debugging purposes.
- */
-const {setTimeout: wait} = require('node:timers/promises'); // Promise-based timer for delays
-
-async function delay(ms, log){
-  if(log){ console.log(`delay is running with ${ms}`); } // logs delay start for debugging
-  await wait(ms); // non-blocking wait using built-in promise timer
-  if(log){ console.log(`delay is returning undefined`); } // logs completion for visibility
-} // wrapper preserves previous logging behavior
 
 /*
  * HTTP REQUEST WITH EXPONENTIAL BACKOFF RETRY LOGIC
@@ -78,60 +64,17 @@ async function fetchRetry(url,opts={},attempts=3){
   */
  if(!('timeout' in opts)){ opts.timeout = 10000; } 
  
-  /*
-   * RETRY LOOP WITH EXPONENTIAL BACKOFF
-   * Rationale: Loop structure enables clean retry logic with progressive delays.
-   * Each iteration represents one complete request attempt with error handling.
-   */
-  for(let i=1;i<=attempts;i++){ 
-   try{
-    /*
-     * HTTP REQUEST EXECUTION
-     * Rationale: axiosInstance.get provides reliable HTTP client with good error handling,
-     * timeout support, and comprehensive response object. Options object allows
-     * caller to specify responseType, headers, and other request configuration.
-     */
-    const res=await axiosInstance.get(url,opts); // uses persistent axios instance for all retries
-   console.log(`fetchRetry is returning ${res.status}`); // Logs successful response status
-   return res; // Returns complete axios response object for caller processing
+  const instance = axios.create({httpAgent:axiosInstance.defaults.httpAgent,httpsAgent:axiosInstance.defaults.httpsAgent}); // creates per-call instance to isolate interceptors
+  axiosRetry(instance,{retries:attempts,retryDelay:axiosRetry.exponentialDelay}); // attaches axios-retry configuration
+  try{
+    const res = await instance.get(url,opts); // performs HTTP request with retry handling
+    console.log(`fetchRetry is returning ${res.status}`); // logs successful status
+    return res; // returns response to caller
   }catch(err){
-   /*
-    * RESOURCE CLEANUP
-    * Rationale: Ensures failed requests don't leak resources, particularly important
-    * for connection pooling and memory management in high-retry scenarios.
-    */
-   if(err.request) {
-     err.request.destroy && err.request.destroy(); // Cleanup hanging request if possible
-   }
-   /*
-    * ERROR LOGGING WITH CONTEXT
-    * Rationale: Each failed attempt is logged with context to enable debugging
-    * of network issues, server problems, or configuration errors. Attempt number
-    * helps identify whether issues are consistent or intermittent.
-    */
-   qerrors(err,`fetch attempt ${i}`,{url,attempt:i}); 
-   
-   /*
-    * FINAL ATTEMPT HANDLING
-    * Rationale: After exhausting all retry attempts, the error is re-thrown
-    * to allow calling code to handle the failure appropriately. This prevents
-    * infinite retry loops while preserving error information.
-    */
-   if(i===attempts){ 
-    throw err; // Re-throws final error for caller to handle
-   }
-   
-   /*
-    * EXPONENTIAL BACKOFF DELAY CALCULATION
-    * Rationale: 2^(attempt-1) * 100ms creates exponential backoff:
-    * - Attempt 1 failure: 100ms delay before attempt 2
-    * - Attempt 2 failure: 200ms delay before attempt 3
-    * This pattern respects struggling servers while enabling quick recovery.
-    */
-  const delayMs=2**(i-1)*100; // calculates exponential backoff in ms
-  await delay(delayMs, true); // waits before next retry attempt with logging
+    if(err.request){ err.request.destroy && err.request.destroy(); } // cleans failed request
+    qerrors(err,'fetchRetry failed',{url}); // logs failure context
+    throw err; // rethrows after logging
   }
- }
 }
 
 /*


### PR DESCRIPTION
## Summary
- add axios-retry dependency
- replace manual retry logic with axios-retry
- update test helper with axios-retry stub for offline tests

## Testing
- `npm test` *(fails: build edge cases due to missing postcss)*

------
https://chatgpt.com/codex/tasks/task_b_684d0e6ce9248322b33808c08523f1f5