### PR TITLE
Improve script detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,10 @@ function injectCss(){ // handles runtime stylesheet loading logic
  console.log(`injectCss is running with ${document.currentScript && document.currentScript.src}`); // logs entry and script src
  try {
   let scriptEl = document.currentScript; // uses current script element when available
-  if(!scriptEl){ scriptEl = document.querySelector('script[src$="index.js" i]'); } // detects loading via standard filename when currentScript missing
+  if(!scriptEl){ // falls back to iterating all script tags when currentScript missing
+   const scripts = Array.from(document.getElementsByTagName('script')); // gathers all script elements for manual search
+   scriptEl = scripts.find(s=>s.src && s.src.toLowerCase().endsWith('index.js')); // finds script with src ending index.js ignoring case
+  }
   if(!scriptEl){ scriptEl = document.querySelector('[data-qorecss]'); } // detects custom attribute for flexible inclusion
   const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : ''; // avoids errors when element or src missing
   const basePath = scriptSrc ? scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1) : document.baseURI; // defaults to document.baseURI when no script found

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -120,8 +120,8 @@ describe('browser injection', {concurrency:false}, () => {
 
   it('detects script element by src pattern', () => {
     const script = document.createElement('script'); // creates script element for lookup
-    script.src = 'https://cdn.example.com/assets/index.js'; // matches src$="index.js"
-    document.body.appendChild(script); // adds script to DOM for querySelector
+    script.src = 'https://cdn.example.com/assets/INDEX.JS'; // uses upper case to test case-insensitive detection
+    document.body.appendChild(script); // adds script to DOM for lookup iteration
     require('../index.js'); // loads module to trigger injection
     const link = document.querySelector('link'); // retrieves injected link
     assert.ok(link.href.startsWith('https://cdn.example.com/assets/')); // verifies base path from script src


### PR DESCRIPTION
## Summary
- iterate over all script tags to find the loading script
- test case-insensitive script detection in browser tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e8fefb5f483228578767be1349ebb