### PR TITLE
Restore require hook cleanup

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -93,6 +93,16 @@ Module.prototype.require = function(id){
 
   return orig.call(this,id); // Preserves normal require behavior for other modules
 };
+/*
+ * REQUIRE RESTORATION RATIONALE:
+ * Tests modify Module.prototype.require to return stubs, so the hook must
+ * be undone once testing completes to avoid polluting subsequent modules.
+ */
+
+if(!global.__restoreRequireHooked){ // ensures cleanup hook added only once
+  process.once('exit', ()=>{ Module.prototype.require = orig; }); // restores original require to prevent stub leakage between test runs
+  global.__restoreRequireHooked = true; // flag prevents duplicate hooks across test files
+}
 
 /*
  * FILE PATH RESOLUTION OVERRIDE


### PR DESCRIPTION
## Summary
- add hook to reset `Module.prototype.require` after tests
- document why the hook is restored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e9054f98083228292e713ab4f4aec