### PR TITLE
Specify utf8 encoding when writing html

### DIFF
--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -98,7 +98,7 @@ async function updateHtml(){
    * Rationale: Writing back to the same file updates references in place.
    * This maintains file permissions and any other metadata while updating content.
    */
-  await fs.writeFile(htmlPath, updated); // Persists updated HTML to disk
+  await fs.writeFile(htmlPath, updated, 'utf8'); // Persists updated HTML using explicit UTF-8 encoding for cross-platform consistency
 
   console.log(`updateHtml has run resulting in core.${hash}.min.css`); // Logs successful completion with resulting filename
   console.log(`updateHtml is returning ${hash}`); // Logs return value for debugging

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -136,6 +136,16 @@ describe('updateHtml', () => {
     assert.strictEqual(count, 2); // both references should be replaced
     assert.strictEqual(hash, '12345678'); // returned hash remains correct
   });
+
+  it('writes file using utf8 encoding', async () => {
+    let encOpt; // stores provided encoding option for assertion
+    const origWrite = fs.promises.writeFile; // save original function for later restoration
+    fs.promises.writeFile = async function(p, d, o){ encOpt = o; return origWrite.call(this, p, d, o); }; // intercepts call to capture encoding while executing original logic
+    const hash = await updateHtml(); // run update to invoke writeFile
+    fs.promises.writeFile = origWrite; // restore original writeFile to avoid cross-test pollution
+    assert.strictEqual(encOpt, 'utf8'); // verify utf8 encoding explicitly passed
+    assert.strictEqual(hash, '12345678'); // ensure function still returns correct hash
+  });
 });
 
 // CLI exit code tests ensure process.exitCode reflects missing build artifacts


### PR DESCRIPTION
## Summary
- explicitly use UTF-8 when writing updated HTML
- verify encoding is set via `fs.writeFile` in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f179b65f48322b92b160b50c7ad93