### PR TITLE
Update performance defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ Configure the build and deployment process:
 CDN_BASE_URL=https://cdn.jsdelivr.net  # CDN endpoint for deployment (trailing slash removed automatically; defaults to jsDelivr when empty)
 
 MAX_CONCURRENCY=50                     # Performance test concurrency limit
-SOCKET_LIMIT=100                       # HTTP connection pool size
+SOCKET_LIMIT=50                        # HTTP connection pool size with lowered default
 
 # Performance Monitoring
-QUEUE_LIMIT=10                         # Request queue size for testing
+QUEUE_LIMIT=5                          # Request queue size for testing with reduced limit
 ```
 
 ## Performance

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -40,11 +40,11 @@ Configure performance testing behavior through environment variables:
 ```bash
 # CDN Configuration
 export CDN_BASE_URL=https://cdn.jsdelivr.net    # Primary CDN endpoint (trailing slash removed automatically; defaults to jsDelivr when empty)
-export MAX_CONCURRENCY=50                        # Maximum concurrent requests (1-1000)  
-export SOCKET_LIMIT=100                          # HTTP connection pool size (1-1000)
+export MAX_CONCURRENCY=50                        # Maximum concurrent requests (1-1000)
+export SOCKET_LIMIT=50                           # HTTP connection pool size (1-1000) with new default
 
 # Testing Parameters
-export QUEUE_LIMIT=10                            # Request queue size (1-100)
+export QUEUE_LIMIT=5                             # Request queue size (1-100) with new default
 export CODEX=true                                # Enable offline testing mode
 
 # Run tests with custom configuration


### PR DESCRIPTION
## Summary
- lower `SOCKET_LIMIT` default to 50
- lower `QUEUE_LIMIT` default to 5

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fb8c7f98083229a7be48d30eb861c