### PR TITLE
Handle missing __dirname

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,16 +41,20 @@ function safeResolve(file){ // resolves path when require is present or falls ba
  try { // ensures error handling
   if(typeof require==='function' && require.resolve){ // checks for CommonJS require availability
    const resolved = require.resolve(file); // resolves absolute path via Node
-   console.log(`safeResolve is returning ${resolved}`); // logs resolved path
+   console.log(`safeResolve is returning ${resolved}`); // logs resolved path chosen via require.resolve
    return resolved; // returns resolved path when in Node
   }
  } catch(err){
   if(errLog){ errLog(err,'safeResolve failed',{file}); } // structured logging when qerrors present
   else { console.error('safeResolve failed:', err.message); } // fallback replicating old behavior
  } // logs unexpected errors
- const abs = path.resolve(__dirname, file); // absolute fallback ensures bundlers find correct file even without require
- console.log(`safeResolve is returning ${abs}`); // logs absolute fallback path
- return abs; // returns absolute path when require unavailable for browser bundling
+ if(typeof __dirname !== 'undefined'){ // checks if __dirname exists for path resolution
+  const abs = path.resolve(__dirname, file); // uses __dirname when defined for absolute fallback
+  console.log(`safeResolve is returning ${abs}`); // logs absolute fallback path from __dirname
+  return abs; // returns absolute path when require unavailable and __dirname present
+ }
+ console.log(`safeResolve is returning ${file}`); // logs unchanged path when __dirname undefined
+ return file; // returns file unchanged when neither require.resolve nor __dirname available
 }
 
 const qorecss = { // holds public API properties and helpers

--- a/test/index.norequire.browser.test.js
+++ b/test/index.norequire.browser.test.js
@@ -10,8 +10,10 @@ describe('browser without require', {concurrency:false}, () => {
   it('loads index.js via script when require undefined', () => {
     const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', {runScripts:'dangerously', url:'https://example.com/'});
     const script = fs.readFileSync(path.resolve(__dirname, '../index.js'), 'utf8');
+    dom.window.eval('var __dirname = undefined;'); // removes dirname so safeResolve uses plain path
     assert.doesNotThrow(() => { dom.window.eval(script); }); // ensures no ReferenceError when require missing
     assert.ok(dom.window.qorecss); // confirms global API exposed
+    assert.strictEqual(dom.window.qorecss.coreCss, './qore.css'); // verifies fallback path without dirname
     dom.window.close();
   });
 });


### PR DESCRIPTION
## Summary
- ensure `safeResolve` works when `__dirname` is not defined
- confirm browser test runs with undefined `__dirname`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850329217d88322a523e03124d62264