### PR TITLE
Add note on performance history limit

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -87,4 +87,4 @@ The testing system measures and reports:
 - **Average Response Time**: Mean response time across all requests
 - **Statistical Analysis**: Includes zero-count protection and range validation
 - **CDN Comparison**: Side-by-side performance comparison between providers
-- **Historical Tracking**: JSON output enables trend analysis over time
+- **Historical Tracking**: JSON output enables trend analysis over time. Only the most recent 50 entries are kept in `performance-results.json`


### PR DESCRIPTION
## Summary
- clarify that performance-results.json is trimmed to 50 entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850abb7f7048322b1db46daefd82a02