### PR TITLE
Update docs for CODEX offline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ SOCKET_LIMIT=50                        # HTTP connection pool size with lowered 
 
 # Performance Monitoring
 QUEUE_LIMIT=5                          # Number of requests run concurrently in each batch
-CODEX=true                             # Enable offline mode for build and test scripts (skip network requests) <!-- clarifies offline mode extends to build and tests -->
+CODEX=true                             # Enable offline mode for build, test, performance, and purge scripts (skip network requests) <!-- clarifies offline mode extends to build, tests, performance, and purge -->
 ```
 
 `MAX_CONCURRENCY` sets the total number of requests processed, while `QUEUE_LIMIT` controls how many run in parallel at a time.
-`CODEX` enables offline mode for build and test scripts so they run without network access.
+`CODEX` enables offline mode for build, test, performance, and purge scripts so they run without network access.
 
 ## Performance
 
@@ -228,7 +228,7 @@ The project automatically builds and deploys to GitHub Pages on every push to `m
 For self-hosting, see [docs/self-hosting.md](docs/self-hosting.md) for optimal server configuration.
 
 ### CDN Cache Purge
-After deployment run `node scripts/purge-cdn.js` to clear CDN caches so the latest hashed files are served. <!-- instructs users how to clear CDN -->
+After deployment run `node scripts/purge-cdn.js` to clear CDN caches so the latest hashed files are served. <!-- instructs users how to clear CDN --> When offline set `CODEX=true` to simulate the purge.
 You can optionally check CDN performance with `node scripts/performance.js --json` which measures response times and writes `performance-results.json`. <!-- explains json output file for tracking -->
 The file is uploaded by `.github/workflows/performance.yml` as an artifact and automatically trimmed to the most recent 50 entries for convenient tracking.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -28,5 +28,5 @@ These directives ensure precompressed `.gz` and `.br` files are served when pres
 ## Hashed file names
 
 The build script renames `core.min.css` to a file containing an eight character SHA‑1 hash (for example `core.77526ae8.min.css`). This unique filename lets you serve the file with `Cache-Control: public, max-age=31536000, immutable` because updates produce a completely new filename. Older hashed files are removed on each build so only the latest hash is present. When a new build is deployed you must purge any CDN caches so the new hashed file is available; otherwise clients may continue receiving the old file for up to a year.
-Run `node scripts/purge-cdn.js` after each build to automate cache purging across providers. <!-- provides recommended script for cache purge -->
+Run `node scripts/purge-cdn.js` after each build to automate cache purging across providers. <!-- provides recommended script for cache purge --> When no network access is available you can set `CODEX=true` to simulate the purge.
 


### PR DESCRIPTION
## Summary
- document extended CODEX offline usage in README
- note CODEX for purge-cdn in README CDN section
- explain CODEX use for purge-cdn in self-hosting guide

## Testing
- `CODEX=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850b31fcd908322965a11728d0e99b3